### PR TITLE
feat: estructura inicial del CV en componentes separados

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,26 @@
-import './App.css'
+import Navbar from "./components/Navbar";
+import Hero from "./sections/Hero";
+import About from "./sections/About";
+import Projects from "./sections/Projects";
+import Experience from "./sections/Experience";
+import Contact from "./sections/Contact";
+import Footer from "./components/Footer";
+import { projects } from "./data/projects";
+import { jobs } from "./data/experience";
 
-function App() {
+export default function App() {
   return (
-    <div className="h-screen flex flex-col items-center justify-center bg-gradient-to-r from-pink-500 to-indigo-500">
-      <h1 className="text-5xl font-bold text-white">Tailwind 4 anda 🚀</h1>
-      <p className="mt-4 text-xl text-yellow-200">Ahora sí con estilos!</p>
-      <button className="mt-6 px-6 py-3 bg-white text-pink-600 font-semibold rounded-lg shadow hover:bg-gray-200">
-        Probame
-      </button>
+    <div className="min-h-screen bg-neutral-950 text-neutral-100 antialiased">
+      <Navbar />
+      <main className="mx-auto max-w-6xl px-4">
+        <Hero />
+        <About />
+        <Projects items={projects} />
+        <Experience items={jobs} />
+        <Contact />
+      </main>
+      <Footer />
     </div>
-  )
+  );
 }
 
-export default App

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,16 @@
+export default function Footer() {
+  return (
+    <footer className="mt-20 border-t border-white/10">
+      <div className="mx-auto max-w-6xl px-4 py-8 flex flex-col md:flex-row items-center justify-between gap-3">
+        <p className="text-sm text-neutral-400">
+          © {new Date().getFullYear()} Gaspar Rambo — Hecho con React + Tailwind
+        </p>
+        <div className="flex items-center gap-4 text-sm">
+          <a className="hover:text-white transition-colors" href="#contacto">Contacto</a>
+          <a className="hover:text-white transition-colors" href="https://github.com/RamboGM" target="_blank">GitHub</a>
+        </div>
+      </div>
+    </footer>
+  );
+}
+

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,25 @@
+export default function Navbar() {
+  return (
+    <header className="sticky top-0 z-50 backdrop-blur bg-neutral-950/80 border-b border-white/10">
+      <nav className="mx-auto max-w-6xl px-4 h-16 flex items-center justify-between">
+        <a href="#" className="font-semibold tracking-tight">
+          <span className="text-pink-400">Gaspar</span>{" "}
+          <span className="text-indigo-400">Rambo</span>
+        </a>
+        <ul className="hidden md:flex items-center gap-6 text-sm text-neutral-300">
+          <li><a className="hover:text-white transition-colors" href="#sobre-mi">Sobre mí</a></li>
+          <li><a className="hover:text-white transition-colors" href="#proyectos">Proyectos</a></li>
+          <li><a className="hover:text-white transition-colors" href="#experiencia">Experiencia</a></li>
+          <li><a className="hover:text-white transition-colors" href="#contacto">Contacto</a></li>
+          <li>
+            <a className="rounded-lg bg-white text-neutral-900 px-3 py-1.5 font-medium hover:bg-neutral-200 transition-colors"
+               href="/cv.pdf" target="_blank" rel="noopener">
+              Descargar CV
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+}
+

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -1,0 +1,18 @@
+export interface Job {
+  company: string;
+  role: string;
+  period: string;
+  summary: string;
+  stack?: string[];
+}
+
+export const jobs: Job[] = [
+  {
+    company: "Partner Tienda Nube",
+    role: "Desarrollador (freelance)",
+    period: "2023 — Actualidad",
+    summary: "Desarrollo de funcionalidades a medida e integraciones para e-commerce. Enfoque en performance, UX y automatización.",
+    stack: ["JavaScript", "TypeScript", "React", "Node.js", "Express", "Python"]
+  }
+];
+

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,25 @@
+export interface Project {
+  title: string;
+  description: string;
+  tech: string[];
+  repo?: string;
+  demo?: string;
+}
+
+export const projects: Project[] = [
+  {
+    title: "Plugin integrador de pagos — WooCommerce",
+    description:
+      "Plugin que conecta WooCommerce con una pasarela de pagos. Autenticación segura, captura de pagos, webhooks y actualización de estados de orden.",
+    tech: ["PHP", "WordPress", "WooCommerce", "REST API"],
+    repo: "https://github.com/RamboGM/tu-repo-woocommerce"
+  },
+  {
+    title: "App para Tienda Nube",
+    description:
+      "Aplicación para checkout mejorado y sincronización de inventario. Panel admin, webhooks y endpoints custom.",
+    tech: ["TypeScript", "React", "Node.js", "Express"],
+    repo: "https://github.com/RamboGM/tu-repo-tiendanube"
+  }
+];
+

--- a/src/sections/About.tsx
+++ b/src/sections/About.tsx
@@ -1,0 +1,18 @@
+export default function About() {
+  return (
+    <section id="sobre-mi" className="scroll-mt-24 py-20">
+      <h2 className="text-3xl md:text-4xl font-bold">Sobre mí</h2>
+      <p className="mt-4 text-neutral-300 leading-relaxed max-w-3xl">
+        Soy desarrollador web con foco en <strong className="text-white">integraciones y e-commerce</strong>.
+        Trabajo como partner de <strong className="text-white">Tienda Nube</strong> y desarrollo plugins / apps
+        que conectan plataformas y mejoran la experiencia de compra.
+      </p>
+      <ul className="mt-6 flex flex-wrap gap-2 text-sm text-neutral-300">
+        {["JavaScript","TypeScript","React","Node.js","Express","Python","PHP","WooCommerce"].map((t) => (
+          <li key={t} className="rounded-full border border-white/10 px-3 py-1 bg-white/5">{t}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -1,0 +1,30 @@
+export default function Contact() {
+  const email = "tu-email@ejemplo.com"; // TODO: reemplazar
+  const subject = encodeURIComponent("Consulta desde tu CV web");
+  const body = encodeURIComponent("Hola Gaspar, me gustaría contactarte por...");
+  const mailto = `mailto:${email}?subject=${subject}&body=${body}`;
+
+  return (
+    <section id="contacto" className="scroll-mt-24 py-20">
+      <div className="grid md:grid-cols-2 gap-8 items-center">
+        <div>
+          <h2 className="text-3xl md:text-4xl font-bold">Contacto</h2>
+          <p className="mt-4 text-neutral-300">¿Tenés un proyecto, integración o idea en mente? Hablemos.</p>
+          <a href={mailto} className="mt-6 inline-block rounded-lg bg-white text-neutral-900 px-5 py-2.5 font-medium hover:bg-neutral-200 transition-colors">
+            Escribime por mail
+          </a>
+          <p className="mt-3 text-sm text-neutral-400">También podés descargar mi CV en PDF desde el menú.</p>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
+          <form onSubmit={(e) => { e.preventDefault(); window.location.href = mailto; }} className="space-y-3">
+            <input className="w-full rounded-lg bg-neutral-900 border border-white/10 px-3 py-2" placeholder="Tu nombre" />
+            <input className="w-full rounded-lg bg-neutral-900 border border-white/10 px-3 py-2" placeholder="Tu email" />
+            <textarea className="w-full rounded-lg bg-neutral-900 border border-white/10 px-3 py-2 h-28" placeholder="Tu mensaje" />
+            <button className="rounded-lg bg-white text-neutral-900 px-4 py-2 font-medium hover:bg-neutral-200 transition-colors">Enviar</button>
+          </form>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -1,0 +1,29 @@
+import type { Job } from "../data/experience";
+
+export default function Experience({ items }: { items: Job[] }) {
+  return (
+    <section id="experiencia" className="scroll-mt-24 py-20">
+      <h2 className="text-3xl md:text-4xl font-bold">Experiencia</h2>
+      <ol className="mt-8 relative border-l border-white/10 pl-6 space-y-8">
+        {items.map((j, i) => (
+          <li key={i} className="relative">
+            <span className="absolute -left-[9px] top-1.5 h-4 w-4 rounded-full bg-gradient-to-r from-pink-500 to-indigo-500"></span>
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+              <div>
+                <h3 className="font-semibold">{j.role} · <span className="text-neutral-300">{j.company}</span></h3>
+                <p className="text-neutral-300 mt-1">{j.summary}</p>
+                {j.stack?.length && (
+                  <ul className="mt-2 flex flex-wrap gap-2 text-xs text-neutral-300">
+                    {j.stack.map((s) => (<li key={s} className="rounded-full border border-white/10 px-2 py-0.5 bg-white/5">{s}</li>))}
+                  </ul>
+                )}
+              </div>
+              <span className="text-sm text-neutral-400">{j.period}</span>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -1,0 +1,26 @@
+export default function Hero() {
+  return (
+    <section className="pt-16 md:pt-20">
+      <div className="mt-16 md:mt-24 rounded-3xl bg-gradient-to-r from-pink-500 to-indigo-500 p-[1px]">
+        <div className="rounded-3xl bg-neutral-950/90 px-6 py-16 md:px-12 md:py-24">
+          <div className="text-center">
+            <p className="text-sm uppercase tracking-widest text-neutral-300">Portfolio / CV</p>
+            <h1 className="mt-2 text-4xl md:text-6xl font-extrabold">Gaspar Rambo</h1>
+            <p className="mt-4 text-lg md:text-xl text-neutral-300">
+              Desarrollador Web · Integraciones & E-commerce (Tienda Nube, WooCommerce)
+            </p>
+            <div className="mt-8 flex items-center justify-center gap-4">
+              <a href="#proyectos" className="rounded-lg bg-white text-neutral-900 px-5 py-2.5 font-medium hover:bg-neutral-200 transition-colors">
+                Ver proyectos
+              </a>
+              <a href="https://github.com/RamboGM" target="_blank" className="rounded-lg bg-white/10 text-white px-5 py-2.5 font-medium hover:bg-white/20 transition-colors">
+                GitHub
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/sections/Projects.tsx
+++ b/src/sections/Projects.tsx
@@ -1,0 +1,40 @@
+import type { Project } from "../data/projects";
+
+function ProjectCard({ p }: { p: Project }) {
+  return (
+    <article className="group rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10 transition-colors">
+      <h3 className="text-lg font-semibold">{p.title}</h3>
+      <p className="mt-2 text-neutral-300">{p.description}</p>
+      <ul className="mt-3 flex flex-wrap gap-2 text-xs text-neutral-300">
+        {p.tech.map((t) => (
+          <li key={t} className="rounded-full border border-white/10 px-2 py-0.5 bg-neutral-900">{t}</li>
+        ))}
+      </ul>
+      <div className="mt-4 flex items-center gap-4 text-sm">
+        {p.repo && (
+          <a href={p.repo} target="_blank" className="text-pink-300 hover:text-pink-200 underline underline-offset-4">Repo</a>
+        )}
+        {p.demo && (
+          <a href={p.demo} target="_blank" className="text-indigo-300 hover:text-indigo-200 underline underline-offset-4">Demo</a>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export default function Projects({ items }: { items: Project[] }) {
+  return (
+    <section id="proyectos" className="scroll-mt-24 py-20">
+      <div className="flex items-end justify-between">
+        <h2 className="text-3xl md:text-4xl font-bold">Proyectos</h2>
+        <a href="https://github.com/RamboGM" target="_blank" className="text-sm text-neutral-300 hover:text-white transition-colors">
+          Ver más en GitHub →
+        </a>
+      </div>
+      <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {items.map((p, i) => (<ProjectCard key={i} p={p} />))}
+      </div>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- reemplazar la composición de `App.tsx` para orquestar secciones y datos del CV
- crear componentes reutilizables de navegación y pie de página con estilos de Tailwind
- añadir secciones de contenido y fuentes de datos tipadas para proyectos y experiencia

## Testing
- npm run build *(falla: falta la dependencia @tailwindcss/postcss en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68c886beeefc8332879919495496b802