### PR TITLE
Add animated hero background and palette refresh

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,21 +5,25 @@ import Projects from "./sections/Projects";
 import Experience from "./sections/Experience";
 import Contact from "./sections/Contact";
 import Footer from "./components/Footer";
+import ParticleBackground from "./components/ParticleBackground";
 import { projects } from "./data/projects";
 import { jobs } from "./data/experience";
 
 export default function App() {
   return (
-    <div className="min-h-screen bg-neutral-950 text-neutral-100 antialiased">
-      <Navbar />
-      <main className="mx-auto max-w-6xl px-4">
-        <Hero />
-        <About />
-        <Projects items={projects} />
-        <Experience items={jobs} />
-        <Contact />
-      </main>
-      <Footer />
+    <div className="relative min-h-screen overflow-hidden bg-[#0f172a] text-[#f1f5f9] antialiased">
+      <ParticleBackground />
+      <div className="relative z-10">
+        <Navbar />
+        <main className="mx-auto max-w-6xl px-4">
+          <Hero />
+          <About />
+          <Projects items={projects} />
+          <Experience items={jobs} />
+          <Contact />
+        </main>
+        <Footer />
+      </div>
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,16 +1,19 @@
 export default function Footer() {
   return (
     <footer className="mt-20 border-t border-white/10">
-      <div className="mx-auto max-w-6xl px-4 py-8 flex flex-col md:flex-row items-center justify-between gap-3">
-        <p className="text-sm text-neutral-400">
+      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-4 py-8 text-sm text-white/60 md:flex-row">
+        <p>
           © {new Date().getFullYear()} Gaspar Rambo — Hecho con React + Tailwind
         </p>
-        <div className="flex items-center gap-4 text-sm">
-          <a className="hover:text-white transition-colors" href="#contacto">Contacto</a>
-          <a className="hover:text-white transition-colors" href="https://github.com/RamboGM" target="_blank">GitHub</a>
+        <div className="flex items-center gap-4">
+          <a className="transition-colors hover:text-[#22d3ee]" href="#contacto">
+            Contacto
+          </a>
+          <a className="transition-colors hover:text-[#ec4899]" href="https://github.com/RamboGM" target="_blank" rel="noopener">
+            GitHub
+          </a>
         </div>
       </div>
     </footer>
   );
 }
-

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,19 +1,40 @@
 export default function Navbar() {
   return (
-    <header className="sticky top-0 z-50 backdrop-blur bg-neutral-950/80 border-b border-white/10">
-      <nav className="mx-auto max-w-6xl px-4 h-16 flex items-center justify-between">
-        <a href="#" className="font-semibold tracking-tight">
-          <span className="text-pink-400">Gaspar</span>{" "}
-          <span className="text-indigo-400">Rambo</span>
+    <header className="sticky top-0 z-50 border-b border-white/10 bg-[rgba(15,23,42,0.8)] backdrop-blur">
+      <nav className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
+        <a href="#" className="text-lg font-semibold tracking-tight">
+          <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+            Gaspar Rambo
+          </span>
         </a>
-        <ul className="hidden md:flex items-center gap-6 text-sm text-neutral-300">
-          <li><a className="hover:text-white transition-colors" href="#sobre-mi">Sobre mí</a></li>
-          <li><a className="hover:text-white transition-colors" href="#proyectos">Proyectos</a></li>
-          <li><a className="hover:text-white transition-colors" href="#experiencia">Experiencia</a></li>
-          <li><a className="hover:text-white transition-colors" href="#contacto">Contacto</a></li>
+        <ul className="hidden items-center gap-6 text-sm text-white/70 md:flex">
           <li>
-            <a className="rounded-lg bg-white text-neutral-900 px-3 py-1.5 font-medium hover:bg-neutral-200 transition-colors"
-               href="/cv.pdf" target="_blank" rel="noopener">
+            <a className="transition-colors hover:text-[#f1f5f9]" href="#sobre-mi">
+              Sobre mí
+            </a>
+          </li>
+          <li>
+            <a className="transition-colors hover:text-[#f1f5f9]" href="#proyectos">
+              Proyectos
+            </a>
+          </li>
+          <li>
+            <a className="transition-colors hover:text-[#f1f5f9]" href="#experiencia">
+              Experiencia
+            </a>
+          </li>
+          <li>
+            <a className="transition-colors hover:text-[#f1f5f9]" href="#contacto">
+              Contacto
+            </a>
+          </li>
+          <li>
+            <a
+              className="rounded-full bg-[#22d3ee] px-4 py-1.5 font-medium text-[#0f172a] shadow-[0_10px_30px_rgba(34,211,238,0.3)] transition-transform hover:-translate-y-0.5 hover:bg-[#22d3ee]/90"
+              href="/cv.pdf"
+              target="_blank"
+              rel="noopener"
+            >
               Descargar CV
             </a>
           </li>

--- a/src/components/ParticleBackground.tsx
+++ b/src/components/ParticleBackground.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useRef } from "react";
+
+type Particle = {
+  x: number;
+  y: number;
+  size: number;
+  vx: number;
+  vy: number;
+  baseVx: number;
+  baseVy: number;
+  color: string;
+};
+
+const colors = [
+  "rgba(236, 72, 153, 0.65)",
+  "rgba(99, 102, 241, 0.55)",
+  "rgba(34, 211, 238, 0.55)",
+];
+
+const MAX_DISTANCE = 140;
+
+export default function ParticleBackground() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number | null>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const pointerRef = useRef({ x: 0, y: 0, active: false });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    const setSize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+      createParticles();
+    };
+
+    const createParticles = () => {
+      const area = canvas.width * canvas.height;
+      const count = Math.min(120, Math.ceil(area / 18000));
+      particlesRef.current = new Array(count).fill(null).map(() => {
+        const angle = Math.random() * Math.PI * 2;
+        const speed = 0.1 + Math.random() * 0.25;
+        const baseVx = Math.cos(angle) * speed;
+        const baseVy = Math.sin(angle) * speed;
+        return {
+          x: Math.random() * canvas.width,
+          y: Math.random() * canvas.height,
+          size: 1.1 + Math.random() * 1.6,
+          vx: baseVx,
+          vy: baseVy,
+          baseVx,
+          baseVy,
+          color: colors[Math.floor(Math.random() * colors.length)],
+        } satisfies Particle;
+      });
+    };
+
+    setSize();
+    window.addEventListener("resize", setSize);
+
+    let pointerTimer: number | undefined;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      pointerRef.current = {
+        x: event.clientX,
+        y: event.clientY,
+        active: true,
+      };
+      if (pointerTimer) {
+        window.clearTimeout(pointerTimer);
+      }
+      pointerTimer = window.setTimeout(() => {
+        pointerRef.current.active = false;
+      }, 160);
+    };
+
+    const handlePointerLeave = () => {
+      pointerRef.current.active = false;
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerleave", handlePointerLeave);
+
+    const draw = () => {
+      context.clearRect(0, 0, canvas.width, canvas.height);
+
+      for (const particle of particlesRef.current) {
+        const { x, y } = particle;
+        const dx = pointerRef.current.x - x;
+        const dy = pointerRef.current.y - y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+
+        if (pointerRef.current.active && distance < MAX_DISTANCE && distance > 0) {
+          const influence = (MAX_DISTANCE - distance) / MAX_DISTANCE;
+          particle.vx += (dx / distance) * influence * 0.12;
+          particle.vy += (dy / distance) * influence * 0.12;
+        } else {
+          particle.vx += (particle.baseVx - particle.vx) * 0.02;
+          particle.vy += (particle.baseVy - particle.vy) * 0.02;
+        }
+
+        particle.x += particle.vx;
+        particle.y += particle.vy;
+
+        if (particle.x < -50) particle.x = canvas.width + 50;
+        if (particle.x > canvas.width + 50) particle.x = -50;
+        if (particle.y < -50) particle.y = canvas.height + 50;
+        if (particle.y > canvas.height + 50) particle.y = -50;
+
+        context.beginPath();
+        context.fillStyle = particle.color;
+        context.arc(particle.x, particle.y, particle.size, 0, Math.PI * 2);
+        context.fill();
+      }
+
+      for (let i = 0; i < particlesRef.current.length; i += 1) {
+        const particleA = particlesRef.current[i];
+        for (let j = i + 1; j < particlesRef.current.length; j += 1) {
+          const particleB = particlesRef.current[j];
+          const dx = particleA.x - particleB.x;
+          const dy = particleA.y - particleB.y;
+          const distance = Math.sqrt(dx * dx + dy * dy);
+
+          if (distance < MAX_DISTANCE) {
+            const opacity = (1 - distance / MAX_DISTANCE) * 0.2;
+            context.strokeStyle = `rgba(99, 102, 241, ${opacity.toFixed(3)})`;
+            context.lineWidth = 0.65;
+            context.beginPath();
+            context.moveTo(particleA.x, particleA.y);
+            context.lineTo(particleB.x, particleB.y);
+            context.stroke();
+          }
+        }
+      }
+
+      animationRef.current = window.requestAnimationFrame(draw);
+    };
+
+    animationRef.current = window.requestAnimationFrame(draw);
+
+    return () => {
+      if (pointerTimer) {
+        window.clearTimeout(pointerTimer);
+      }
+      if (animationRef.current !== null) {
+        window.cancelAnimationFrame(animationRef.current);
+      }
+      window.removeEventListener("resize", setSize);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerleave", handlePointerLeave);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="pointer-events-none fixed inset-0 z-0 h-full w-full"
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,119 @@
 @import "tailwindcss";
 
 :root {
-  color-scheme: light dark;
+  color-scheme: dark;
+  --color-base: #0f172a;
+  --color-primary: #ec4899;
+  --color-secondary: #6366f1;
+  --color-accent: #22d3ee;
+  --color-text: #f1f5f9;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: var(--color-base);
+  color: var(--color-text);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: -0.01em;
+}
+
+.hexagon-frame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1;
+  display: block;
+  filter: drop-shadow(0 28px 50px rgba(34, 211, 238, 0.15));
+  animation: float 14s ease-in-out infinite;
+}
+
+.hexagon-border {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  padding: 6%;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary), var(--color-accent));
+  clip-path: polygon(25% 6.7%, 75% 6.7%, 100% 50%, 75% 93.3%, 25% 93.3%, 0% 50%);
+  display: grid;
+  place-items: center;
+  transition: transform 0.6s ease;
+}
+
+.hexagon-frame:hover .hexagon-border {
+  transform: translateY(-4px) scale(1.01);
+}
+
+.hero-avatar {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  clip-path: polygon(25% 6.7%, 75% 6.7%, 100% 50%, 75% 93.3%, 25% 93.3%, 0% 50%);
+  background-color: rgba(15, 23, 42, 0.85);
+  background-position: center;
+  background-size: cover;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  isolation: isolate;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: rgba(241, 245, 249, 0.65);
+}
+
+.hero-avatar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 35% 25%, rgba(236, 72, 153, 0.35), transparent 60%),
+    radial-gradient(circle at 75% 75%, rgba(34, 211, 238, 0.35), transparent 65%);
+  mix-blend-mode: screen;
+  opacity: 0.75;
+  animation: shimmer 12s ease-in-out infinite;
+}
+
+.hero-avatar::after {
+  content: "";
+  position: absolute;
+  inset: -30%;
+  background: conic-gradient(from 0deg, rgba(236, 72, 153, 0), rgba(236, 72, 153, 0.25), rgba(99, 102, 241, 0.25),
+      rgba(34, 211, 238, 0));
+  opacity: 0.4;
+  animation: rotate 18s linear infinite;
+}
+
+.hexagon-frame span {
+  position: relative;
+  z-index: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+}
+
+@keyframes float {
+  0% {
+    transform: translateY(0px) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-10px) rotate(1deg);
+  }
+  100% {
+    transform: translateY(0px) rotate(0deg);
+  }
+}
+
+@keyframes shimmer {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: translate3d(-4%, -4%, 0);
+  }
+  50% {
+    opacity: 0.8;
+    transform: translate3d(4%, 4%, 0);
+  }
+}
+
+@keyframes rotate {
+  to {
+    transform: rotate(1turn);
+  }
 }

--- a/src/sections/About.tsx
+++ b/src/sections/About.tsx
@@ -1,18 +1,29 @@
 export default function About() {
   return (
     <section id="sobre-mi" className="scroll-mt-24 py-20">
-      <h2 className="text-3xl md:text-4xl font-bold">Sobre mí</h2>
-      <p className="mt-4 text-neutral-300 leading-relaxed max-w-3xl">
-        Soy desarrollador web con foco en <strong className="text-white">integraciones y e-commerce</strong>.
-        Trabajo como partner de <strong className="text-white">Tienda Nube</strong> y desarrollo plugins / apps
-        que conectan plataformas y mejoran la experiencia de compra.
+      <div>
+        <h2 className="text-3xl font-bold md:text-4xl">
+          <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+            Sobre mí
+          </span>
+        </h2>
+        <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-transparent" />
+      </div>
+      <p className="mt-6 max-w-3xl text-base leading-relaxed text-white/70 md:text-lg">
+        Soy desarrollador web con foco en <strong className="text-[#f1f5f9]">integraciones y e-commerce</strong>. Trabajo como
+        partner de <strong className="text-[#f1f5f9]">Tienda Nube</strong> y desarrollo plugins y aplicaciones que conectan
+        plataformas, automatizan procesos y mejoran la experiencia de compra.
       </p>
-      <ul className="mt-6 flex flex-wrap gap-2 text-sm text-neutral-300">
-        {["JavaScript","TypeScript","React","Node.js","Express","Python","PHP","WooCommerce"].map((t) => (
-          <li key={t} className="rounded-full border border-white/10 px-3 py-1 bg-white/5">{t}</li>
+      <ul className="mt-8 flex flex-wrap gap-2 text-sm text-white/70">
+        {["JavaScript", "TypeScript", "React", "Node.js", "Express", "Python", "PHP", "WooCommerce"].map((t) => (
+          <li
+            key={t}
+            className="rounded-full border border-[#22d3ee]/30 bg-[#22d3ee]/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#f1f5f9]"
+          >
+            {t}
+          </li>
         ))}
       </ul>
     </section>
   );
 }
-

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -6,25 +6,57 @@ export default function Contact() {
 
   return (
     <section id="contacto" className="scroll-mt-24 py-20">
-      <div className="grid md:grid-cols-2 gap-8 items-center">
-        <div>
-          <h2 className="text-3xl md:text-4xl font-bold">Contacto</h2>
-          <p className="mt-4 text-neutral-300">¿Tenés un proyecto, integración o idea en mente? Hablemos.</p>
-          <a href={mailto} className="mt-6 inline-block rounded-lg bg-white text-neutral-900 px-5 py-2.5 font-medium hover:bg-neutral-200 transition-colors">
+      <div className="grid items-center gap-10 md:grid-cols-2">
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-3xl font-bold md:text-4xl">
+              <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+                Contacto
+              </span>
+            </h2>
+            <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#22d3ee] to-transparent" />
+          </div>
+          <p className="text-base text-white/70 md:text-lg">
+            ¿Tenés un proyecto, integración o idea en mente? Hablemos y diseñemos una solución a medida.
+          </p>
+          <a
+            href={mailto}
+            className="inline-flex w-fit items-center gap-2 rounded-full bg-[#22d3ee] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_18px_48px_rgba(34,211,238,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[#22d3ee]/90"
+          >
             Escribime por mail
           </a>
-          <p className="mt-3 text-sm text-neutral-400">También podés descargar mi CV en PDF desde el menú.</p>
+          <p className="text-xs uppercase tracking-[0.3em] text-white/40">Descargá mi CV desde el menú principal</p>
         </div>
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-          <form onSubmit={(e) => { e.preventDefault(); window.location.href = mailto; }} className="space-y-3">
-            <input className="w-full rounded-lg bg-neutral-900 border border-white/10 px-3 py-2" placeholder="Tu nombre" />
-            <input className="w-full rounded-lg bg-neutral-900 border border-white/10 px-3 py-2" placeholder="Tu email" />
-            <textarea className="w-full rounded-lg bg-neutral-900 border border-white/10 px-3 py-2 h-28" placeholder="Tu mensaje" />
-            <button className="rounded-lg bg-white text-neutral-900 px-4 py-2 font-medium hover:bg-neutral-200 transition-colors">Enviar</button>
+        <div className="relative rounded-3xl border border-white/10 bg-[rgba(15,23,42,0.8)] p-6 shadow-[0_30px_80px_rgba(15,23,42,0.55)]">
+          <div className="pointer-events-none absolute -right-6 -top-6 h-24 w-24 rounded-full bg-[#ec4899]/25 blur-3xl" />
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              window.location.href = mailto;
+            }}
+            className="relative space-y-4"
+          >
+            <input
+              className="w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#22d3ee] focus:outline-none focus:ring-2 focus:ring-[#22d3ee]/40"
+              placeholder="Tu nombre"
+            />
+            <input
+              className="w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#22d3ee] focus:outline-none focus:ring-2 focus:ring-[#22d3ee]/40"
+              placeholder="Tu email"
+              type="email"
+            />
+            <textarea
+              className="h-32 w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#ec4899] focus:outline-none focus:ring-2 focus:ring-[#ec4899]/30"
+              placeholder="Tu mensaje"
+            />
+            <button
+              className="w-full rounded-full bg-[#ec4899] px-4 py-3 text-sm font-semibold text-[#0f172a] transition-transform hover:-translate-y-0.5 hover:bg-[#ec4899]/90"
+            >
+              Enviar mensaje
+            </button>
           </form>
         </div>
       </div>
     </section>
   );
 }
-

--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -3,22 +3,35 @@ import type { Job } from "../data/experience";
 export default function Experience({ items }: { items: Job[] }) {
   return (
     <section id="experiencia" className="scroll-mt-24 py-20">
-      <h2 className="text-3xl md:text-4xl font-bold">Experiencia</h2>
-      <ol className="mt-8 relative border-l border-white/10 pl-6 space-y-8">
+      <div>
+        <h2 className="text-3xl font-bold md:text-4xl">
+          <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+            Experiencia
+          </span>
+        </h2>
+        <div className="mt-3 h-[3px] w-28 rounded-full bg-gradient-to-r from-[#6366f1] to-transparent" />
+      </div>
+      <ol className="relative mt-10 space-y-10 border-l border-white/10 pl-6">
         {items.map((j, i) => (
           <li key={i} className="relative">
-            <span className="absolute -left-[9px] top-1.5 h-4 w-4 rounded-full bg-gradient-to-r from-pink-500 to-indigo-500"></span>
-            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
-              <div>
-                <h3 className="font-semibold">{j.role} · <span className="text-neutral-300">{j.company}</span></h3>
-                <p className="text-neutral-300 mt-1">{j.summary}</p>
-                {j.stack?.length && (
-                  <ul className="mt-2 flex flex-wrap gap-2 text-xs text-neutral-300">
-                    {j.stack.map((s) => (<li key={s} className="rounded-full border border-white/10 px-2 py-0.5 bg-white/5">{s}</li>))}
+            <span className="absolute -left-[10px] top-2 block h-5 w-5 rounded-full bg-gradient-to-br from-[#ec4899] via-[#6366f1] to-[#22d3ee] shadow-[0_0_25px_rgba(99,102,241,0.4)]" />
+            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div className="space-y-2">
+                <h3 className="text-lg font-semibold text-[#f1f5f9]">
+                  {j.role} · <span className="font-medium text-white/70">{j.company}</span>
+                </h3>
+                <p className="text-sm text-white/70 md:text-base">{j.summary}</p>
+                {j.stack?.length ? (
+                  <ul className="mt-2 flex flex-wrap gap-2 text-xs text-white/60">
+                    {j.stack.map((s) => (
+                      <li key={s} className="rounded-full border border-white/10 bg-[rgba(15,23,42,0.8)] px-2 py-0.5">
+                        {s}
+                      </li>
+                    ))}
                   </ul>
-                )}
+                ) : null}
               </div>
-              <span className="text-sm text-neutral-400">{j.period}</span>
+              <span className="text-xs font-medium uppercase tracking-widest text-white/50 md:text-sm">{j.period}</span>
             </div>
           </li>
         ))}
@@ -26,4 +39,3 @@ export default function Experience({ items }: { items: Job[] }) {
     </section>
   );
 }
-

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -1,21 +1,65 @@
 export default function Hero() {
   return (
-    <section className="pt-16 md:pt-20">
-      <div className="mt-16 md:mt-24 rounded-3xl bg-gradient-to-r from-pink-500 to-indigo-500 p-[1px]">
-        <div className="rounded-3xl bg-neutral-950/90 px-6 py-16 md:px-12 md:py-24">
-          <div className="text-center">
-            <p className="text-sm uppercase tracking-widest text-neutral-300">Portfolio / CV</p>
-            <h1 className="mt-2 text-4xl md:text-6xl font-extrabold">Gaspar Rambo</h1>
-            <p className="mt-4 text-lg md:text-xl text-neutral-300">
-              Desarrollador Web · Integraciones & E-commerce (Tienda Nube, WooCommerce)
-            </p>
-            <div className="mt-8 flex items-center justify-center gap-4">
-              <a href="#proyectos" className="rounded-lg bg-white text-neutral-900 px-5 py-2.5 font-medium hover:bg-neutral-200 transition-colors">
-                Ver proyectos
-              </a>
-              <a href="https://github.com/RamboGM" target="_blank" className="rounded-lg bg-white/10 text-white px-5 py-2.5 font-medium hover:bg-white/20 transition-colors">
-                GitHub
-              </a>
+    <section className="relative pt-20 md:pt-24">
+      <div className="mt-16 md:mt-20">
+        <div className="rounded-[2.75rem] bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] p-[1px] shadow-[0_40px_120px_rgba(34,211,238,0.18)]">
+          <div className="relative overflow-hidden rounded-[2.7rem] bg-[rgba(15,23,42,0.85)] px-6 py-16 md:px-14 md:py-20">
+            <div className="absolute -left-24 -top-24 h-64 w-64 rounded-full bg-[#ec4899]/20 blur-3xl" aria-hidden="true" />
+            <div className="absolute -bottom-32 -right-16 h-72 w-72 rounded-full bg-[#22d3ee]/20 blur-[120px]" aria-hidden="true" />
+            <div className="relative grid items-center gap-12 md:grid-cols-[minmax(0,1fr)_minmax(220px,320px)]">
+              <div className="space-y-6 text-left">
+                <span className="inline-flex items-center gap-2 rounded-full border border-[#22d3ee]/40 bg-[#22d3ee]/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-[#22d3ee]">
+                  Portfolio · CV
+                </span>
+                <h1 className="text-4xl font-extrabold leading-tight md:text-6xl">
+                  <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+                    Gaspar Rambo
+                  </span>
+                </h1>
+                <p className="max-w-xl text-lg text-white/70 md:text-xl">
+                  Desarrollador web especializado en integraciones y comercio electrónico. Conecto plataformas como Tienda
+                  Nube y WooCommerce para crear experiencias de compra memorables.
+                </p>
+                <div className="flex flex-wrap gap-4">
+                  <a
+                    href="#proyectos"
+                    className="rounded-full bg-[#ec4899] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_20px_60px_rgba(236,72,153,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[#ec4899]/90"
+                  >
+                    Ver proyectos
+                  </a>
+                  <a
+                    href="https://github.com/RamboGM"
+                    target="_blank"
+                    className="rounded-full border border-[#6366f1]/60 px-6 py-2.5 text-sm font-semibold text-white/80 transition-all hover:-translate-y-0.5 hover:border-[#22d3ee]/80 hover:text-[#f1f5f9]"
+                    rel="noopener"
+                  >
+                    GitHub
+                  </a>
+                </div>
+                <div className="flex flex-wrap gap-6 text-sm text-white/60">
+                  <div className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-[#22d3ee]" />
+                    Integraciones & Automatizaciones
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-[#ec4899]" />
+                    E-commerce a medida
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-[#6366f1]" />
+                    Experiencias centradas en el usuario
+                  </div>
+                </div>
+              </div>
+              <div className="mx-auto w-48 sm:w-56 md:w-full">
+                <div className="hexagon-frame">
+                  <div className="hexagon-border">
+                    <div className="hero-avatar">
+                      <span>Tu foto</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/sections/Projects.tsx
+++ b/src/sections/Projects.tsx
@@ -2,20 +2,37 @@ import type { Project } from "../data/projects";
 
 function ProjectCard({ p }: { p: Project }) {
   return (
-    <article className="group rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10 transition-colors">
-      <h3 className="text-lg font-semibold">{p.title}</h3>
-      <p className="mt-2 text-neutral-300">{p.description}</p>
-      <ul className="mt-3 flex flex-wrap gap-2 text-xs text-neutral-300">
+    <article className="group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm transition-all hover:border-[#22d3ee]/50 hover:bg-[#22d3ee]/10">
+      <div className="pointer-events-none absolute -right-10 top-1/3 h-32 w-32 rounded-full bg-[#6366f1]/20 blur-3xl transition-transform duration-700 ease-out group-hover:translate-x-3 group-hover:-translate-y-4" />
+      <h3 className="text-lg font-semibold text-[#f1f5f9]">{p.title}</h3>
+      <p className="mt-2 text-sm text-white/70">{p.description}</p>
+      <ul className="mt-4 flex flex-wrap gap-2 text-xs text-white/60">
         {p.tech.map((t) => (
-          <li key={t} className="rounded-full border border-white/10 px-2 py-0.5 bg-neutral-900">{t}</li>
+          <li key={t} className="rounded-full border border-white/10 bg-[rgba(15,23,42,0.8)] px-2 py-0.5">
+            {t}
+          </li>
         ))}
       </ul>
-      <div className="mt-4 flex items-center gap-4 text-sm">
+      <div className="mt-6 flex items-center gap-4 text-sm">
         {p.repo && (
-          <a href={p.repo} target="_blank" className="text-pink-300 hover:text-pink-200 underline underline-offset-4">Repo</a>
+          <a
+            href={p.repo}
+            target="_blank"
+            className="font-medium text-[#22d3ee] transition-colors hover:text-[#22d3ee]/70"
+            rel="noopener"
+          >
+            Repo
+          </a>
         )}
         {p.demo && (
-          <a href={p.demo} target="_blank" className="text-indigo-300 hover:text-indigo-200 underline underline-offset-4">Demo</a>
+          <a
+            href={p.demo}
+            target="_blank"
+            className="font-medium text-[#ec4899] transition-colors hover:text-[#ec4899]/80"
+            rel="noopener"
+          >
+            Demo
+          </a>
         )}
       </div>
     </article>
@@ -25,16 +42,31 @@ function ProjectCard({ p }: { p: Project }) {
 export default function Projects({ items }: { items: Project[] }) {
   return (
     <section id="proyectos" className="scroll-mt-24 py-20">
-      <div className="flex items-end justify-between">
-        <h2 className="text-3xl md:text-4xl font-bold">Proyectos</h2>
-        <a href="https://github.com/RamboGM" target="_blank" className="text-sm text-neutral-300 hover:text-white transition-colors">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h2 className="text-3xl font-bold md:text-4xl">
+            <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+              Proyectos
+            </span>
+          </h2>
+          <p className="mt-2 text-sm text-white/60 md:text-base">
+            Selección de integraciones, tiendas y automatizaciones que impulsan resultados.
+          </p>
+        </div>
+        <a
+          href="https://github.com/RamboGM"
+          target="_blank"
+          className="text-sm font-medium text-white/70 transition-colors hover:text-[#22d3ee]"
+          rel="noopener"
+        >
           Ver más en GitHub →
         </a>
       </div>
-      <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {items.map((p, i) => (<ProjectCard key={i} p={p} />))}
+      <div className="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((p, i) => (
+          <ProjectCard key={i} p={p} />
+        ))}
       </div>
     </section>
   );
 }
-


### PR DESCRIPTION
## Summary
- add a reusable particle background canvas and switch the app container to the dark blue base tone
- redesign the hero with a left-aligned layout, gradient CTAs and an animated hexagon avatar placeholder for future photography
- refresh supporting sections, navigation and footer to apply the pink/indigo/cyan palette across typography, buttons and cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c890a8a438833296247541d1171ecd