### PR TITLE
feat: switch site to funky sunset palette

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { jobs } from "./data/experience";
 
 export default function App() {
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#0f172a] text-[#f1f5f9] antialiased">
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-[#f43f5e] to-[#8b5cf6] text-[#f1f5f9] antialiased">
       <ParticleBackground />
       <div className="relative z-10">
         <Navbar />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,10 +6,10 @@ export default function Footer() {
           © {new Date().getFullYear()} Gaspar Rambo — Hecho con React + Tailwind
         </p>
         <div className="flex items-center gap-4">
-          <a className="transition-colors hover:text-[#22d3ee]" href="#contacto">
+          <a className="transition-colors hover:text-[#10b981]" href="#contacto">
             Contacto
           </a>
-          <a className="transition-colors hover:text-[#ec4899]" href="https://github.com/RamboGM" target="_blank" rel="noopener">
+          <a className="transition-colors hover:text-[#f43f5e]" href="https://github.com/RamboGM" target="_blank" rel="noopener">
             GitHub
           </a>
         </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,9 +1,9 @@
 export default function Navbar() {
   return (
-    <header className="sticky top-0 z-50 border-b border-white/10 bg-[rgba(15,23,42,0.8)] backdrop-blur">
+    <header className="sticky top-0 z-50 border-b border-white/10 bg-[rgba(15,23,42,0.6)] backdrop-blur">
       <nav className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
         <a href="#" className="text-lg font-semibold tracking-tight">
-          <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+          <span className="bg-gradient-to-r from-[#facc15] via-[#f43f5e] to-[#8b5cf6] bg-clip-text text-transparent">
             Gaspar Rambo
           </span>
         </a>
@@ -30,7 +30,7 @@ export default function Navbar() {
           </li>
           <li>
             <a
-              className="rounded-full bg-[#22d3ee] px-4 py-1.5 font-medium text-[#0f172a] shadow-[0_10px_30px_rgba(34,211,238,0.3)] transition-transform hover:-translate-y-0.5 hover:bg-[#22d3ee]/90"
+              className="rounded-full bg-[#10b981] px-4 py-1.5 font-medium text-[#022c22] shadow-[0_10px_30px_rgba(16,185,129,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[#0ea371]"
               href="/cv.pdf"
               target="_blank"
               rel="noopener"

--- a/src/components/ParticleBackground.tsx
+++ b/src/components/ParticleBackground.tsx
@@ -12,9 +12,10 @@ type Particle = {
 };
 
 const colors = [
-  "rgba(236, 72, 153, 0.65)",
-  "rgba(99, 102, 241, 0.55)",
-  "rgba(34, 211, 238, 0.55)",
+  "rgba(244, 63, 94, 0.18)",
+  "rgba(139, 92, 246, 0.16)",
+  "rgba(16, 185, 129, 0.14)",
+  "rgba(250, 204, 21, 0.18)",
 ];
 
 const MAX_DISTANCE = 140;
@@ -40,7 +41,7 @@ export default function ParticleBackground() {
 
     const createParticles = () => {
       const area = canvas.width * canvas.height;
-      const count = Math.min(120, Math.ceil(area / 18000));
+      const count = Math.min(220, Math.ceil(area / 12000));
       particlesRef.current = new Array(count).fill(null).map(() => {
         const angle = Math.random() * Math.PI * 2;
         const speed = 0.1 + Math.random() * 0.25;
@@ -49,7 +50,7 @@ export default function ParticleBackground() {
         return {
           x: Math.random() * canvas.width,
           y: Math.random() * canvas.height,
-          size: 1.1 + Math.random() * 1.6,
+          size: 0.8 + Math.random() * 1.3,
           vx: baseVx,
           vy: baseVy,
           baseVx,
@@ -115,26 +116,6 @@ export default function ParticleBackground() {
         context.fillStyle = particle.color;
         context.arc(particle.x, particle.y, particle.size, 0, Math.PI * 2);
         context.fill();
-      }
-
-      for (let i = 0; i < particlesRef.current.length; i += 1) {
-        const particleA = particlesRef.current[i];
-        for (let j = i + 1; j < particlesRef.current.length; j += 1) {
-          const particleB = particlesRef.current[j];
-          const dx = particleA.x - particleB.x;
-          const dy = particleA.y - particleB.y;
-          const distance = Math.sqrt(dx * dx + dy * dy);
-
-          if (distance < MAX_DISTANCE) {
-            const opacity = (1 - distance / MAX_DISTANCE) * 0.2;
-            context.strokeStyle = `rgba(99, 102, 241, ${opacity.toFixed(3)})`;
-            context.lineWidth = 0.65;
-            context.beginPath();
-            context.moveTo(particleA.x, particleA.y);
-            context.lineTo(particleB.x, particleB.y);
-            context.stroke();
-          }
-        }
       }
 
       animationRef.current = window.requestAnimationFrame(draw);

--- a/src/index.css
+++ b/src/index.css
@@ -2,17 +2,19 @@
 
 :root {
   color-scheme: dark;
-  --color-base: #0f172a;
-  --color-primary: #ec4899;
-  --color-secondary: #6366f1;
-  --color-accent: #22d3ee;
+  --color-base-start: #f43f5e;
+  --color-base-end: #8b5cf6;
+  --color-primary: #10b981;
+  --color-secondary: #8b5cf6;
+  --color-accent: #facc15;
   --color-text: #f1f5f9;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background-color: var(--color-base);
+  background: radial-gradient(circle at 15% 20%, rgba(250, 204, 21, 0.18), transparent 55%),
+    linear-gradient(135deg, var(--color-base-start), var(--color-base-end));
   color: var(--color-text);
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   letter-spacing: -0.01em;
@@ -23,7 +25,7 @@ body {
   width: 100%;
   aspect-ratio: 1;
   display: block;
-  filter: drop-shadow(0 28px 50px rgba(34, 211, 238, 0.15));
+  filter: drop-shadow(0 28px 50px rgba(16, 185, 129, 0.18));
   animation: float 14s ease-in-out infinite;
 }
 
@@ -32,7 +34,7 @@ body {
   width: 100%;
   height: 100%;
   padding: 6%;
-  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary), var(--color-accent));
+  background: linear-gradient(135deg, var(--color-accent), var(--color-primary), var(--color-secondary));
   clip-path: polygon(25% 6.7%, 75% 6.7%, 100% 50%, 75% 93.3%, 25% 93.3%, 0% 50%);
   display: grid;
   place-items: center;
@@ -48,7 +50,7 @@ body {
   width: 100%;
   height: 100%;
   clip-path: polygon(25% 6.7%, 75% 6.7%, 100% 50%, 75% 93.3%, 25% 93.3%, 0% 50%);
-  background-color: rgba(15, 23, 42, 0.85);
+  background-color: rgba(15, 23, 42, 0.82);
   background-position: center;
   background-size: cover;
   display: grid;
@@ -64,8 +66,8 @@ body {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 35% 25%, rgba(236, 72, 153, 0.35), transparent 60%),
-    radial-gradient(circle at 75% 75%, rgba(34, 211, 238, 0.35), transparent 65%);
+  background: radial-gradient(circle at 35% 25%, rgba(244, 63, 94, 0.28), transparent 60%),
+    radial-gradient(circle at 75% 75%, rgba(250, 204, 21, 0.25), transparent 65%);
   mix-blend-mode: screen;
   opacity: 0.75;
   animation: shimmer 12s ease-in-out infinite;
@@ -75,8 +77,8 @@ body {
   content: "";
   position: absolute;
   inset: -30%;
-  background: conic-gradient(from 0deg, rgba(236, 72, 153, 0), rgba(236, 72, 153, 0.25), rgba(99, 102, 241, 0.25),
-      rgba(34, 211, 238, 0));
+  background: conic-gradient(from 0deg, rgba(244, 63, 94, 0), rgba(244, 63, 94, 0.22), rgba(139, 92, 246, 0.22),
+      rgba(16, 185, 129, 0));
   opacity: 0.4;
   animation: rotate 18s linear infinite;
 }

--- a/src/sections/About.tsx
+++ b/src/sections/About.tsx
@@ -3,11 +3,11 @@ export default function About() {
     <section id="sobre-mi" className="scroll-mt-24 py-20">
       <div>
         <h2 className="text-3xl font-bold md:text-4xl">
-          <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+          <span className="bg-gradient-to-r from-[#facc15] via-[#f43f5e] to-[#8b5cf6] bg-clip-text text-transparent">
             Sobre mí
           </span>
         </h2>
-        <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-transparent" />
+        <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#facc15] via-[#f43f5e] to-transparent" />
       </div>
       <p className="mt-6 max-w-3xl text-base leading-relaxed text-white/70 md:text-lg">
         Soy desarrollador web con foco en <strong className="text-[#f1f5f9]">integraciones y e-commerce</strong>. Trabajo como
@@ -18,7 +18,7 @@ export default function About() {
         {["JavaScript", "TypeScript", "React", "Node.js", "Express", "Python", "PHP", "WooCommerce"].map((t) => (
           <li
             key={t}
-            className="rounded-full border border-[#22d3ee]/30 bg-[#22d3ee]/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#f1f5f9]"
+            className="rounded-full border border-[#10b981]/40 bg-[#10b981]/15 px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#f1f5f9]"
           >
             {t}
           </li>

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -10,25 +10,25 @@ export default function Contact() {
         <div className="space-y-6">
           <div>
             <h2 className="text-3xl font-bold md:text-4xl">
-              <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+              <span className="bg-gradient-to-r from-[#facc15] via-[#f43f5e] to-[#8b5cf6] bg-clip-text text-transparent">
                 Contacto
               </span>
             </h2>
-            <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#22d3ee] to-transparent" />
+            <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#10b981] via-[#facc15] to-transparent" />
           </div>
           <p className="text-base text-white/70 md:text-lg">
             ¿Tenés un proyecto, integración o idea en mente? Hablemos y diseñemos una solución a medida.
           </p>
           <a
             href={mailto}
-            className="inline-flex w-fit items-center gap-2 rounded-full bg-[#22d3ee] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_18px_48px_rgba(34,211,238,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[#22d3ee]/90"
+            className="inline-flex w-fit items-center gap-2 rounded-full bg-[#10b981] px-6 py-2.5 text-sm font-semibold text-[#022c22] shadow-[0_18px_48px_rgba(16,185,129,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[#0ea371]"
           >
             Escribime por mail
           </a>
           <p className="text-xs uppercase tracking-[0.3em] text-white/40">Descargá mi CV desde el menú principal</p>
         </div>
-        <div className="relative rounded-3xl border border-white/10 bg-[rgba(15,23,42,0.8)] p-6 shadow-[0_30px_80px_rgba(15,23,42,0.55)]">
-          <div className="pointer-events-none absolute -right-6 -top-6 h-24 w-24 rounded-full bg-[#ec4899]/25 blur-3xl" />
+        <div className="relative rounded-3xl border border-white/10 bg-[rgba(15,23,42,0.78)] p-6 shadow-[0_30px_80px_rgba(15,23,42,0.55)]">
+          <div className="pointer-events-none absolute -right-6 -top-6 h-24 w-24 rounded-full bg-[#8b5cf6]/25 blur-3xl" />
           <form
             onSubmit={(e) => {
               e.preventDefault();
@@ -37,20 +37,20 @@ export default function Contact() {
             className="relative space-y-4"
           >
             <input
-              className="w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#22d3ee] focus:outline-none focus:ring-2 focus:ring-[#22d3ee]/40"
+              className="w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.78)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#10b981] focus:outline-none focus:ring-2 focus:ring-[#10b981]/40"
               placeholder="Tu nombre"
             />
             <input
-              className="w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#22d3ee] focus:outline-none focus:ring-2 focus:ring-[#22d3ee]/40"
+              className="w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.78)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#10b981] focus:outline-none focus:ring-2 focus:ring-[#10b981]/40"
               placeholder="Tu email"
               type="email"
             />
             <textarea
-              className="h-32 w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#ec4899] focus:outline-none focus:ring-2 focus:ring-[#ec4899]/30"
+              className="h-32 w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.78)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#f43f5e] focus:outline-none focus:ring-2 focus:ring-[#f43f5e]/35"
               placeholder="Tu mensaje"
             />
             <button
-              className="w-full rounded-full bg-[#ec4899] px-4 py-3 text-sm font-semibold text-[#0f172a] transition-transform hover:-translate-y-0.5 hover:bg-[#ec4899]/90"
+              className="w-full rounded-full bg-[#10b981] px-4 py-3 text-sm font-semibold text-[#022c22] transition-transform hover:-translate-y-0.5 hover:bg-[#0ea371]"
             >
               Enviar mensaje
             </button>

--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -5,16 +5,16 @@ export default function Experience({ items }: { items: Job[] }) {
     <section id="experiencia" className="scroll-mt-24 py-20">
       <div>
         <h2 className="text-3xl font-bold md:text-4xl">
-          <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+          <span className="bg-gradient-to-r from-[#facc15] via-[#f43f5e] to-[#8b5cf6] bg-clip-text text-transparent">
             Experiencia
           </span>
         </h2>
-        <div className="mt-3 h-[3px] w-28 rounded-full bg-gradient-to-r from-[#6366f1] to-transparent" />
+        <div className="mt-3 h-[3px] w-28 rounded-full bg-gradient-to-r from-[#8b5cf6] via-[#facc15] to-transparent" />
       </div>
       <ol className="relative mt-10 space-y-10 border-l border-white/10 pl-6">
         {items.map((j, i) => (
           <li key={i} className="relative">
-            <span className="absolute -left-[10px] top-2 block h-5 w-5 rounded-full bg-gradient-to-br from-[#ec4899] via-[#6366f1] to-[#22d3ee] shadow-[0_0_25px_rgba(99,102,241,0.4)]" />
+            <span className="absolute -left-[10px] top-2 block h-5 w-5 rounded-full bg-gradient-to-br from-[#f43f5e] via-[#facc15] to-[#8b5cf6] shadow-[0_0_25px_rgba(139,92,246,0.35)]" />
             <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
               <div className="space-y-2">
                 <h3 className="text-lg font-semibold text-[#f1f5f9]">

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -2,17 +2,17 @@ export default function Hero() {
   return (
     <section className="relative pt-20 md:pt-24">
       <div className="mt-16 md:mt-20">
-        <div className="rounded-[2.75rem] bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] p-[1px] shadow-[0_40px_120px_rgba(34,211,238,0.18)]">
-          <div className="relative overflow-hidden rounded-[2.7rem] bg-[rgba(15,23,42,0.85)] px-6 py-16 md:px-14 md:py-20">
-            <div className="absolute -left-24 -top-24 h-64 w-64 rounded-full bg-[#ec4899]/20 blur-3xl" aria-hidden="true" />
-            <div className="absolute -bottom-32 -right-16 h-72 w-72 rounded-full bg-[#22d3ee]/20 blur-[120px]" aria-hidden="true" />
+        <div className="rounded-[2.75rem] bg-gradient-to-r from-[#f43f5e] via-[#fb7185] to-[#8b5cf6] p-[1px] shadow-[0_40px_120px_rgba(244,63,94,0.18)]">
+          <div className="relative overflow-hidden rounded-[2.7rem] bg-[rgba(15,23,42,0.8)] px-6 py-16 md:px-14 md:py-20">
+            <div className="absolute -left-24 -top-24 h-64 w-64 rounded-full bg-[#f43f5e]/25 blur-3xl" aria-hidden="true" />
+            <div className="absolute -bottom-32 -right-16 h-72 w-72 rounded-full bg-[#8b5cf6]/20 blur-[120px]" aria-hidden="true" />
             <div className="relative grid items-center gap-12 md:grid-cols-[minmax(0,1fr)_minmax(220px,320px)]">
               <div className="space-y-6 text-left">
-                <span className="inline-flex items-center gap-2 rounded-full border border-[#22d3ee]/40 bg-[#22d3ee]/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-[#22d3ee]">
+                <span className="inline-flex items-center gap-2 rounded-full border border-[#facc15]/50 bg-[#facc15]/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-[#facc15]">
                   Portfolio · CV
                 </span>
                 <h1 className="text-4xl font-extrabold leading-tight md:text-6xl">
-                  <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+                  <span className="bg-gradient-to-r from-[#facc15] via-[#f43f5e] to-[#8b5cf6] bg-clip-text text-transparent">
                     Gaspar Rambo
                   </span>
                 </h1>
@@ -23,14 +23,14 @@ export default function Hero() {
                 <div className="flex flex-wrap gap-4">
                   <a
                     href="#proyectos"
-                    className="rounded-full bg-[#ec4899] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_20px_60px_rgba(236,72,153,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[#ec4899]/90"
+                    className="rounded-full bg-[#10b981] px-6 py-2.5 text-sm font-semibold text-[#022c22] shadow-[0_20px_60px_rgba(16,185,129,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[#0ea371]"
                   >
                     Ver proyectos
                   </a>
                   <a
                     href="https://github.com/RamboGM"
                     target="_blank"
-                    className="rounded-full border border-[#6366f1]/60 px-6 py-2.5 text-sm font-semibold text-white/80 transition-all hover:-translate-y-0.5 hover:border-[#22d3ee]/80 hover:text-[#f1f5f9]"
+                    className="rounded-full border border-white/30 px-6 py-2.5 text-sm font-semibold text-white/80 transition-all hover:-translate-y-0.5 hover:border-[#facc15]/70 hover:text-[#f1f5f9]"
                     rel="noopener"
                   >
                     GitHub
@@ -38,15 +38,15 @@ export default function Hero() {
                 </div>
                 <div className="flex flex-wrap gap-6 text-sm text-white/60">
                   <div className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-[#22d3ee]" />
+                    <span className="h-2 w-2 rounded-full bg-[#facc15]" />
                     Integraciones & Automatizaciones
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-[#ec4899]" />
+                    <span className="h-2 w-2 rounded-full bg-[#f43f5e]" />
                     E-commerce a medida
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-[#6366f1]" />
+                    <span className="h-2 w-2 rounded-full bg-[#8b5cf6]" />
                     Experiencias centradas en el usuario
                   </div>
                 </div>

--- a/src/sections/Projects.tsx
+++ b/src/sections/Projects.tsx
@@ -2,8 +2,8 @@ import type { Project } from "../data/projects";
 
 function ProjectCard({ p }: { p: Project }) {
   return (
-    <article className="group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm transition-all hover:border-[#22d3ee]/50 hover:bg-[#22d3ee]/10">
-      <div className="pointer-events-none absolute -right-10 top-1/3 h-32 w-32 rounded-full bg-[#6366f1]/20 blur-3xl transition-transform duration-700 ease-out group-hover:translate-x-3 group-hover:-translate-y-4" />
+    <article className="group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm transition-all hover:border-[#10b981]/60 hover:bg-[#10b981]/10">
+      <div className="pointer-events-none absolute -right-10 top-1/3 h-32 w-32 rounded-full bg-[#facc15]/15 blur-3xl transition-transform duration-700 ease-out group-hover:translate-x-3 group-hover:-translate-y-4" />
       <h3 className="text-lg font-semibold text-[#f1f5f9]">{p.title}</h3>
       <p className="mt-2 text-sm text-white/70">{p.description}</p>
       <ul className="mt-4 flex flex-wrap gap-2 text-xs text-white/60">
@@ -18,7 +18,7 @@ function ProjectCard({ p }: { p: Project }) {
           <a
             href={p.repo}
             target="_blank"
-            className="font-medium text-[#22d3ee] transition-colors hover:text-[#22d3ee]/70"
+            className="font-medium text-[#10b981] transition-colors hover:text-[#0ea371]"
             rel="noopener"
           >
             Repo
@@ -28,7 +28,7 @@ function ProjectCard({ p }: { p: Project }) {
           <a
             href={p.demo}
             target="_blank"
-            className="font-medium text-[#ec4899] transition-colors hover:text-[#ec4899]/80"
+            className="font-medium text-[#f43f5e] transition-colors hover:text-[#fb7185]"
             rel="noopener"
           >
             Demo
@@ -45,7 +45,7 @@ export default function Projects({ items }: { items: Project[] }) {
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
           <h2 className="text-3xl font-bold md:text-4xl">
-            <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-[#facc15] via-[#f43f5e] to-[#8b5cf6] bg-clip-text text-transparent">
               Proyectos
             </span>
           </h2>
@@ -56,7 +56,7 @@ export default function Projects({ items }: { items: Project[] }) {
         <a
           href="https://github.com/RamboGM"
           target="_blank"
-          className="text-sm font-medium text-white/70 transition-colors hover:text-[#22d3ee]"
+          className="text-sm font-medium text-white/70 transition-colors hover:text-[#10b981]"
           rel="noopener"
         >
           Ver más en GitHub →


### PR DESCRIPTION
## Summary
- replace the base background and component accents with the Funky Sunset gradient palette
- recolor buttons, headings, and chips to use emerald calls-to-action and yellow detail highlights
- soften and densify the particle canvas, removing connecting lines for a subtle ambient effect

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c899b6f380833293c64c0cb92b67f8