### PR TITLE
Add hero subtitle and fix experience timeline dot

### DIFF
--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -14,7 +14,7 @@ export default function Experience({ items }: { items: Job[] }) {
       <ol className="relative mt-10 space-y-10 border-l border-white/10 pl-6">
         {items.map((j, i) => (
           <li key={i} className="relative">
-            <span className="absolute -left-[10px] top-2 block h-5 w-5 rounded-full bg-gradient-to-br from-[#ec4899] via-[#6366f1] to-[#22d3ee] shadow-[0_0_25px_rgba(99,102,241,0.4)]" />
+            <span className="absolute -left-6 top-2 block h-5 w-5 rounded-full bg-gradient-to-br from-[#ec4899] via-[#6366f1] to-[#22d3ee] shadow-[0_0_25px_rgba(99,102,241,0.4)]" />
             <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
               <div className="space-y-2">
                 <h3 className="text-lg font-semibold text-[#f1f5f9]">

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -16,6 +16,9 @@ export default function Hero() {
                     Gaspar Rambo
                   </span>
                 </h1>
+                <p className="text-xl font-semibold text-white/80 md:text-2xl">
+                  Desarrollador de soluciones a medida impulsadas por IA
+                </p>
                 <p className="max-w-xl text-lg text-white/70 md:text-xl">
                   Desarrollador web especializado en integraciones y comercio electrónico. Conecto plataformas como Tienda
                   Nube y WooCommerce para crear experiencias de compra memorables.


### PR DESCRIPTION
## Summary
- add a dedicated IA-focused tagline under the main hero name
- adjust the experience timeline marker so the gradient dot sits beside the text instead of overlapping it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4509b38f08332bfa3a8b7b5c83d29