### PR TITLE
Remove bundled hero photo and restore placeholder

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -49,6 +49,7 @@ body {
   height: 100%;
   clip-path: polygon(25% 6.7%, 75% 6.7%, 100% 50%, 75% 93.3%, 25% 93.3%, 0% 50%);
   background-color: rgba(15, 23, 42, 0.85);
+  background-image: var(--hero-avatar-image, none);
   background-position: center;
   background-size: cover;
   display: grid;
@@ -58,6 +59,11 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.3em;
   color: rgba(241, 245, 249, 0.65);
+}
+
+.hero-avatar span {
+  position: relative;
+  z-index: 1;
 }
 
 .hero-avatar::before {
@@ -86,6 +92,14 @@ body {
   z-index: 1;
   text-transform: uppercase;
   letter-spacing: 0.25em;
+}
+
+.hero-avatar--with-image {
+  color: transparent;
+}
+
+.hero-avatar--with-image span {
+  opacity: 0;
 }
 
 @keyframes float {

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -1,4 +1,14 @@
+import type { CSSProperties } from "react";
+
+// Define aquí la ruta de la imagen (por ejemplo, "/hero-photo.png") una vez que la subas manualmente
+const heroAvatarImage = "";
+
 export default function Hero() {
+  const hasAvatarImage = heroAvatarImage.trim().length > 0;
+  const heroAvatarStyles = hasAvatarImage
+    ? ({ "--hero-avatar-image": `url(${heroAvatarImage})` } as CSSProperties)
+    : undefined;
+
   return (
     <section className="relative pt-20 md:pt-24">
       <div className="mt-16 md:mt-20">
@@ -57,7 +67,10 @@ export default function Hero() {
               <div className="mx-auto w-48 sm:w-56 md:w-full">
                 <div className="hexagon-frame">
                   <div className="hexagon-border">
-                    <div className="hero-avatar">
+                    <div
+                      className={`hero-avatar${hasAvatarImage ? " hero-avatar--with-image" : ""}`}
+                      style={heroAvatarStyles}
+                    >
                       <span>Tu foto</span>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- remove the bundled portrait asset so the repository no longer ships binary images
- restore the hero avatar placeholder while allowing an optional custom image via CSS custom property
- document where to set the custom image path inside the hero section component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d457101d288332ba99fd1b2b0ed20d