### PR TITLE
Fix CV download by lazy-loading PDF dependencies

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,4 @@
 import { useCallback, useRef } from "react";
-import html2canvas from "html2canvas";
-import jsPDF from "jspdf";
 import Navbar from "./components/Navbar";
 import Hero from "./sections/Hero";
 import About from "./sections/About";
@@ -21,6 +19,10 @@ export default function App() {
     }
 
     const element = mainRef.current;
+    const [{ default: html2canvas }, { default: JsPDF }] = await Promise.all([
+      import("html2canvas"),
+      import("jspdf"),
+    ]);
     const scale = Math.max(
       typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1,
       2,
@@ -35,7 +37,7 @@ export default function App() {
     );
 
     const imageData = canvas.toDataURL("image/png");
-    const pdf = new jsPDF("p", "mm", "a4");
+    const pdf = new JsPDF("p", "mm", "a4");
     const pdfWidth = pdf.internal.pageSize.getWidth();
     const pdfHeight = pdf.internal.pageSize.getHeight();
     const imgWidth = pdfWidth;


### PR DESCRIPTION
## Summary
- lazily import html2canvas and jsPDF when generating the CV to avoid loading them during the initial render

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c60c5f188332bdaac17ab2e24114