### PR TITLE
Improve PDF export fidelity

### DIFF
--- a/src/components/ParticleBackground.tsx
+++ b/src/components/ParticleBackground.tsx
@@ -158,7 +158,7 @@ export default function ParticleBackground() {
   return (
     <canvas
       ref={canvasRef}
-      className="pointer-events-none fixed inset-0 z-0 h-full w-full"
+      className="pointer-events-none fixed inset-0 z-0 h-full w-full pdf-hide"
       aria-hidden="true"
     />
   );

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,49 @@ body {
   letter-spacing: -0.01em;
 }
 
+[data-pdf-root].pdf-export {
+  position: relative;
+  isolation: isolate;
+}
+
+[data-pdf-root].pdf-export::before,
+[data-pdf-root].pdf-export::after {
+  content: "";
+  position: absolute;
+  inset: auto;
+  z-index: 0;
+  border-radius: 9999px;
+  pointer-events: none;
+  opacity: 0.85;
+}
+
+[data-pdf-root].pdf-export::before {
+  width: min(640px, 70vw);
+  height: min(640px, 70vw);
+  top: -12%;
+  left: -8%;
+  background: radial-gradient(circle, rgba(236, 72, 153, 0.18), transparent 70%);
+  filter: blur(40px);
+}
+
+[data-pdf-root].pdf-export::after {
+  width: min(560px, 60vw);
+  height: min(560px, 60vw);
+  bottom: -18%;
+  right: -6%;
+  background: radial-gradient(circle, rgba(34, 211, 238, 0.16), transparent 72%);
+  filter: blur(60px);
+}
+
+[data-pdf-root].pdf-export .pdf-hide {
+  display: none !important;
+}
+
+[data-pdf-root].pdf-export > * {
+  position: relative;
+  z-index: 1;
+}
+
 .hexagon-frame {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- refine the PDF export routine to capture the whole landing page, resolve Tailwind color-mix rules and compress the captured image so the generated file mirrors the site while weighing far less
- add PDF-only background glows and hide the animated particle canvas during exports to keep the static look aligned with the live landing

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5cd7375b88332bc210653ffd058f3