### PR TITLE
Add bilingual support with dynamic language switcher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from "react";
+import type { MutableRefObject } from "react";
 import Navbar from "./components/Navbar";
 import Hero from "./sections/Hero";
 import About from "./sections/About";
@@ -7,8 +8,10 @@ import Experience from "./sections/Experience";
 import Contact from "./sections/Contact";
 import Footer from "./components/Footer";
 import ParticleBackground from "./components/ParticleBackground";
-import { projects } from "./data/projects";
-import { jobs } from "./data/experience";
+import { projectsByLanguage } from "./data/projects";
+import { jobsByLanguage } from "./data/experience";
+import { LanguageProvider } from "./contexts/LanguageProvider";
+import { useLanguage } from "./hooks/useLanguage";
 
 type JsPDFInstance = {
   internal: { pageSize: { getWidth: () => number; getHeight: () => number } };
@@ -181,6 +184,36 @@ const removeUnsupportedColorFunctions = (targetDocument: Document | null) => {
   }
 };
 
+type AppContentProps = {
+  pageRef: MutableRefObject<HTMLDivElement | null>;
+  onDownloadCv: () => Promise<void>;
+};
+
+function AppContent({ pageRef, onDownloadCv }: AppContentProps) {
+  const { language } = useLanguage();
+
+  return (
+    <div
+      ref={pageRef}
+      data-pdf-root
+      className="relative min-h-screen overflow-hidden bg-[#0f172a] text-[#f1f5f9] antialiased"
+    >
+      <ParticleBackground />
+      <div className="relative z-10">
+        <Navbar onDownloadCv={onDownloadCv} />
+        <main className="mx-auto max-w-6xl px-4">
+          <Hero />
+          <About />
+          <Projects items={projectsByLanguage[language]} />
+          <Experience items={jobsByLanguage[language]} />
+          <Contact />
+        </main>
+        <Footer />
+      </div>
+    </div>
+  );
+}
+
 export default function App() {
   const pageRef = useRef<HTMLDivElement | null>(null);
 
@@ -256,24 +289,9 @@ export default function App() {
   }, []);
 
   return (
-    <div
-      ref={pageRef}
-      data-pdf-root
-      className="relative min-h-screen overflow-hidden bg-[#0f172a] text-[#f1f5f9] antialiased"
-    >
-      <ParticleBackground />
-      <div className="relative z-10">
-        <Navbar onDownloadCv={handleDownloadCv} />
-        <main className="mx-auto max-w-6xl px-4">
-          <Hero />
-          <About />
-          <Projects items={projects} />
-          <Experience items={jobs} />
-          <Contact />
-        </main>
-        <Footer />
-      </div>
-    </div>
+    <LanguageProvider>
+      <AppContent pageRef={pageRef} onDownloadCv={handleDownloadCv} />
+    </LanguageProvider>
   );
 }
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,16 +1,19 @@
+import { useLanguage } from "../hooks/useLanguage";
+
 export default function Footer() {
+  const { content } = useLanguage();
+  const footerCopy = content.footer;
+
   return (
     <footer className="mt-20 border-t border-white/10">
       <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-4 py-8 text-sm text-white/60 md:flex-row">
-        <p>
-          © {new Date().getFullYear()} Gaspar Rambo — Hecho con React + Tailwind
-        </p>
+        <p>© {new Date().getFullYear()} Gaspar Rambo — {footerCopy.signature}</p>
         <div className="flex items-center gap-4">
           <a className="transition-colors hover:text-[#22d3ee]" href="#contacto">
-            Contacto
+            {footerCopy.contact}
           </a>
           <a className="transition-colors hover:text-[#ec4899]" href="https://github.com/RamboGM" target="_blank" rel="noopener">
-            GitHub
+            {footerCopy.github}
           </a>
         </div>
       </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,19 +1,19 @@
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 
-const navigationLinks = [
-  { href: "#sobre-mi", label: "Sobre mí" },
-  { href: "#proyectos", label: "Proyectos" },
-  { href: "#experiencia", label: "Experiencia" },
-  { href: "#contacto", label: "Contacto" },
-];
+import { useLanguage } from "../hooks/useLanguage";
+import type { Language } from "../types/language";
 
 type NavbarProps = {
   onDownloadCv?: () => Promise<void> | void;
 };
 
+const AVAILABLE_LANGUAGES: Language[] = ["en", "es"];
+
 export default function Navbar({ onDownloadCv }: NavbarProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
+  const { content, language, setLanguage } = useLanguage();
+  const navigationLinks = content.nav.links;
 
   useEffect(() => {
     if (typeof document === "undefined") {
@@ -48,6 +48,29 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
     }
   };
 
+  const renderLanguageSwitcher = (className: string, separatorClass: string) => (
+    <div className={className} aria-label={content.nav.languageSwitcherLabel}>
+      {AVAILABLE_LANGUAGES.map((code, index) => (
+        <Fragment key={code}>
+          {index > 0 ? <span className={separatorClass}>|</span> : null}
+          <button
+            type="button"
+            onClick={() => {
+              if (language !== code) {
+                setLanguage(code);
+              }
+            }}
+            className={`transition-colors ${
+              language === code ? "text-[#22d3ee]" : "hover:text-white/80"
+            }`}
+          >
+            {code.toUpperCase()}
+          </button>
+        </Fragment>
+      ))}
+    </div>
+  );
+
   return (
     <header className="sticky top-0 z-50 border-b border-white/10 bg-[rgba(15,23,42,0.85)] backdrop-blur">
       <nav className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
@@ -79,6 +102,7 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
               </a>
             </li>
           ))}
+          <li>{renderLanguageSwitcher("flex items-center gap-1 rounded-full border border-white/10 bg-[#0f172a]/40 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-white/60", "text-white/30")}</li>
           <li>
             <button
               type="button"
@@ -86,7 +110,9 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
               onClick={handleDownload}
               disabled={isDownloading}
             >
-              <span className="relative">{isDownloading ? "Generando CV..." : "Descargar CV"}</span>
+              <span className="relative">
+                {isDownloading ? content.nav.download.loading : content.nav.download.idle}
+              </span>
             </button>
           </li>
         </ul>
@@ -96,14 +122,14 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
           onClick={toggleMenu}
           className="relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-[#38bdf8] via-[#818cf8] to-[#f472b6] text-slate-900 shadow-[0_18px_40px_rgba(56,189,248,0.4)] transition-transform duration-300 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-[#38bdf8]/60 focus:ring-offset-2 focus:ring-offset-[#0f172a] md:hidden"
           aria-expanded={isMenuOpen}
-          aria-label={isMenuOpen ? "Cerrar menú de navegación" : "Abrir menú de navegación"}
+          aria-label={isMenuOpen ? content.nav.closeMenuAria : content.nav.openMenuAria}
         >
           <span
             className={`text-[10px] font-semibold uppercase tracking-[0.3em] transition-all duration-300 ${
               isMenuOpen ? "translate-y-2 opacity-0" : "translate-y-0 opacity-100"
             }`}
           >
-            Menú
+            {content.nav.menuLabel}
           </span>
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -144,7 +170,13 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
             className="absolute -bottom-24 -left-12 h-52 w-52 rounded-full bg-[#f472b6]/30 blur-3xl"
           />
           <div className="relative z-10">
-            <p className="text-xs uppercase tracking-[0.4em] text-white/50">Explorar</p>
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-xs uppercase tracking-[0.4em] text-white/50">{content.nav.exploreTitle}</p>
+              {renderLanguageSwitcher(
+                "flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-white/60",
+                "text-white/30"
+              )}
+            </div>
             <ul className="mt-6 space-y-4">
               {navigationLinks.map((item) => (
                 <li key={item.href}>
@@ -177,7 +209,7 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
               }}
               disabled={isDownloading}
             >
-              {isDownloading ? "Generando CV..." : "Descargar CV"}
+              {isDownloading ? content.nav.download.loading : content.nav.download.idle}
             </button>
           </div>
         </div>

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,12 @@
+import { createContext } from "react";
+
+import type { Translation } from "../i18n/translations";
+import type { Language } from "../types/language";
+
+export interface LanguageContextValue {
+  language: Language;
+  setLanguage: (language: Language) => void;
+  content: Translation;
+}
+
+export const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);

--- a/src/contexts/LanguageProvider.tsx
+++ b/src/contexts/LanguageProvider.tsx
@@ -1,0 +1,21 @@
+import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+import { translations } from "../i18n/translations";
+import type { Language } from "../types/language";
+import { LanguageContext } from "./LanguageContext";
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguage] = useState<Language>("es");
+
+  const value = useMemo(
+    () => ({
+      language,
+      setLanguage,
+      content: translations[language]
+    }),
+    [language]
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -1,3 +1,5 @@
+import type { Language } from "../types/language";
+
 export interface Job {
   company: string;
   role: string;
@@ -6,12 +8,25 @@ export interface Job {
   stack?: string[];
 }
 
-export const jobs: Job[] = [
-  {
-    company: "Tienda Pocket",
-    role: "Full-Stack Web Developer & Technical Support Engineer",
-    period: "2024 — Actualidad",
-    summary: "Desarrollo de funcionalidades a medida e integraciones para entorno web, aplicaciones para Tiendanube como partner tecnológico. Enfoque en performance, UX y automatización.",
-    stack: ["JavaScript", "TypeScript", "React", "Node.js", "Express", "Python"]
-  }
-];
+export const jobsByLanguage: Record<Language, Job[]> = {
+  es: [
+    {
+      company: "Tienda Pocket",
+      role: "Full-Stack Web Developer & Technical Support Engineer",
+      period: "2024 — Actualidad",
+      summary:
+        "Desarrollo de funcionalidades a medida e integraciones para entorno web, aplicaciones para Tiendanube como partner tecnológico. Enfoque en performance, UX y automatización.",
+      stack: ["JavaScript", "TypeScript", "React", "Node.js", "Express", "Python"]
+    }
+  ],
+  en: [
+    {
+      company: "Tienda Pocket",
+      role: "Full-Stack Web Developer & Technical Support Engineer",
+      period: "2024 — Present",
+      summary:
+        "Build bespoke features and integrations for Tiendanube merchants. Deliver partner apps focused on performance, UX, and automation across the web stack.",
+      stack: ["JavaScript", "TypeScript", "React", "Node.js", "Express", "Python"]
+    }
+  ]
+};

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,3 +1,5 @@
+import type { Language } from "../types/language";
+
 export interface Project {
   title: string;
   description: string;
@@ -6,27 +8,52 @@ export interface Project {
   demo?: string;
 }
 
-export const projects: Project[] = [
-  {
-    title: "Plugin integrador de plataforma de cobros recurrentes con WooCommerce",
-    description:
-      "El integrador gestiona la comunicación bidireccional entre la plataforma de cobros recurrentes y el sitio en WordPress, autenticando peticiones, enviando operaciones de alta y cambios de planes, y escuchando notificaciones para actualizar estados de usuarios, membresías y accesos en tiempo real.",
-    tech: ["PHP", "WordPress", "WooCommerce", "REST API"],
-    repo: "https://github.com/RamboGM/boxful-woo-integration/"
-  },
-  {
-    title: "App Tabla de Talles | Tiendanube",
-    description:
-      "Es una app para Tienda Nube que agrega en la página de producto un botón “Tabla de talles” que abre un modal/drawer liviano con una imagen de la guía, y te permite desde un panel simple subir y asignar imágenes por producto/categoría/variante, definir una imagen por defecto, opciones de visibilidad, soporte móvil y multi-idioma, todo con carga rápida y sin romper el theme.",
-    tech: ["TypeScript", "React", "Node.js", "Express"],
-    repo: "https://github.com/RamboGM/tabla-talles-tn"
-  },
-  {
-    title: "Sincronizador Factusol | Tiendanube",
-    description:
-      "Sincronizador Factusol es una aplicación externa para Tiendanube que extrae y normaliza datos de productos desde bases de datos Factusol en Microsoft Access, permitiendo gestionar precios, stock y altas desde una interfaz de escritorio Tkinter con programación de sincronizaciones automáticas. Además ofrece utilidades de exportación CSV y expone endpoints Flask para instalación y webhooks dentro del ecosistema Tiendanube, pudiendo empaquetarse como ejecutable para operadores de Windows.",
-    tech: ["Python", "Tkinter", "Flask", "APScheduler", "Pandas", "PyODBC", "Requests", "python-dotenv", "PyInstaller"],
-    repo: "https://github.com/RamboGM/sincronizador_factusol_TN"
-  }
-];
+export const projectsByLanguage: Record<Language, Project[]> = {
+  es: [
+    {
+      title: "Plugin integrador de plataforma de cobros recurrentes con WooCommerce",
+      description:
+        "El integrador gestiona la comunicación bidireccional entre la plataforma de cobros recurrentes y el sitio en WordPress, autenticando peticiones, enviando operaciones de alta y cambios de planes, y escuchando notificaciones para actualizar estados de usuarios, membresías y accesos en tiempo real.",
+      tech: ["PHP", "WordPress", "WooCommerce", "REST API"],
+      repo: "https://github.com/RamboGM/boxful-woo-integration/"
+    },
+    {
+      title: "App Tabla de Talles | Tiendanube",
+      description:
+        "Es una app para Tienda Nube que agrega en la página de producto un botón “Tabla de talles” que abre un modal/drawer liviano con una imagen de la guía, y te permite desde un panel simple subir y asignar imágenes por producto/categoría/variante, definir una imagen por defecto, opciones de visibilidad, soporte móvil y multi-idioma, todo con carga rápida y sin romper el theme.",
+      tech: ["TypeScript", "React", "Node.js", "Express"],
+      repo: "https://github.com/RamboGM/tabla-talles-tn"
+    },
+    {
+      title: "Sincronizador Factusol | Tiendanube",
+      description:
+        "Sincronizador Factusol es una aplicación externa para Tiendanube que extrae y normaliza datos de productos desde bases de datos Factusol en Microsoft Access, permitiendo gestionar precios, stock y altas desde una interfaz de escritorio Tkinter con programación de sincronizaciones automáticas. Además ofrece utilidades de exportación CSV y expone endpoints Flask para instalación y webhooks dentro del ecosistema Tiendanube, pudiendo empaquetarse como ejecutable para operadores de Windows.",
+      tech: ["Python", "Tkinter", "Flask", "APScheduler", "Pandas", "PyODBC", "Requests", "python-dotenv", "PyInstaller"],
+      repo: "https://github.com/RamboGM/sincronizador_factusol_TN"
+    }
+  ],
+  en: [
+    {
+      title: "Recurring Billing Gateway Connector for WooCommerce",
+      description:
+        "Bi-directional integration between a subscription billing platform and a WordPress site. Handles authenticated requests, customer onboarding, plan upgrades, and listens to webhooks to sync member status, entitlements, and real-time access across both systems.",
+      tech: ["PHP", "WordPress", "WooCommerce", "REST API"],
+      repo: "https://github.com/RamboGM/boxful-woo-integration/"
+    },
+    {
+      title: "Size Chart App | Tiendanube",
+      description:
+        "Lightweight Tiendanube app that injects a \"Size chart\" trigger on product pages. Merchants can upload and assign guides by product, category, or variant, define fallbacks, control visibility, and serve responsive multi-language modals—all without compromising theme performance.",
+      tech: ["TypeScript", "React", "Node.js", "Express"],
+      repo: "https://github.com/RamboGM/tabla-talles-tn"
+    },
+    {
+      title: "Factusol Sync | Tiendanube",
+      description:
+        "External Tiendanube integration that ingests product data from Factusol Microsoft Access databases, normalises catalog information, and manages pricing and stock through a Tkinter desktop console with scheduled syncs. Ships CSV export tools and Flask endpoints for installers and webhooks, and can be packaged as a Windows-ready executable.",
+      tech: ["Python", "Tkinter", "Flask", "APScheduler", "Pandas", "PyODBC", "Requests", "python-dotenv", "PyInstaller"],
+      repo: "https://github.com/RamboGM/sincronizador_factusol_TN"
+    }
+  ]
+};
 

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+
+import { LanguageContext } from "../contexts/LanguageContext";
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+
+  return context;
+};

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1,0 +1,218 @@
+import type { Language } from "../types/language";
+
+interface NavLinkTranslation {
+  href: string;
+  label: string;
+}
+
+interface NavTranslation {
+  links: NavLinkTranslation[];
+  download: {
+    idle: string;
+    loading: string;
+  };
+  menuLabel: string;
+  openMenuAria: string;
+  closeMenuAria: string;
+  exploreTitle: string;
+  languageSwitcherLabel: string;
+}
+
+interface HeroTranslation {
+  badge: string;
+  title: string;
+  description: string;
+  primaryCta: string;
+  secondaryCta: string;
+  highlights: string[];
+  avatarFallback: string;
+}
+
+interface AboutTranslation {
+  heading: string;
+  description: string;
+  skills: string[];
+}
+
+interface ProjectsTranslation {
+  heading: string;
+  subtitle: string;
+  viewMore: string;
+}
+
+interface ExperienceTranslation {
+  heading: string;
+}
+
+interface ContactTranslation {
+  heading: string;
+  description: string;
+  button: string;
+  note: string;
+  form: {
+    name: string;
+    email: string;
+    message: string;
+    submit: string;
+    subject: string;
+    body: string;
+  };
+}
+
+interface FooterTranslation {
+  signature: string;
+  contact: string;
+  github: string;
+}
+
+export interface Translation {
+  nav: NavTranslation;
+  hero: HeroTranslation;
+  about: AboutTranslation;
+  projects: ProjectsTranslation;
+  experience: ExperienceTranslation;
+  contact: ContactTranslation;
+  footer: FooterTranslation;
+}
+
+const sectionAnchors = {
+  about: "#sobre-mi",
+  projects: "#proyectos",
+  experience: "#experiencia",
+  contact: "#contacto"
+};
+
+export const translations: Record<Language, Translation> = {
+  es: {
+    nav: {
+      links: [
+        { href: sectionAnchors.about, label: "Sobre mí" },
+        { href: sectionAnchors.projects, label: "Proyectos" },
+        { href: sectionAnchors.experience, label: "Experiencia" },
+        { href: sectionAnchors.contact, label: "Contacto" }
+      ],
+      download: {
+        idle: "Descargar CV",
+        loading: "Generando CV..."
+      },
+      menuLabel: "Menú",
+      openMenuAria: "Abrir menú de navegación",
+      closeMenuAria: "Cerrar menú de navegación",
+      exploreTitle: "Explorar",
+      languageSwitcherLabel: "Cambiar idioma"
+    },
+    hero: {
+      badge: "Portfolio · CV",
+      title: "Desarrollador de soluciones a medida impulsadas por IA",
+      description:
+        "Desarrollador web especializado en integraciones para e-commerce. Conecto plataformas como Tiendanube y WooCommerce con soluciones para mejorar la experiencia de usuario.",
+      primaryCta: "Ver proyectos",
+      secondaryCta: "GitHub",
+      highlights: [
+        "Integraciones & Automatizaciones",
+        "E-commerce a medida",
+        "Experiencias centradas en el usuario"
+      ],
+      avatarFallback: "Tu foto"
+    },
+    about: {
+      heading: "Sobre mí",
+      description:
+        "Soy desarrollador de software con experiencia en entorno web con foco en integraciones y e-commerce. Todos mis desarrollos son creados mediante IA. Trabajo como partner tecnológico de Tiendanube y desarrollo plugins e integraciones que conectan plataformas, automatizan procesos y mejoran la experiencia de usuario.",
+      skills: ["JavaScript", "TypeScript", "React", "Node.js", "Express", "Python", "PHP", "WooCommerce"]
+    },
+    projects: {
+      heading: "Proyectos",
+      subtitle: "Selección de integraciones, plugins y automatizaciones que impulsan resultados.",
+      viewMore: "Ver más en GitHub →"
+    },
+    experience: {
+      heading: "Experiencia"
+    },
+    contact: {
+      heading: "Contacto",
+      description: "¿Tenés un proyecto, integración o idea en mente? Hablemos y diseñemos una solución a medida.",
+      button: "Escribime por mail",
+      note: "Descargá mi CV desde el menú principal",
+      form: {
+        name: "Tu nombre",
+        email: "Tu email",
+        message: "Tu mensaje",
+        submit: "Enviar mensaje",
+        subject: "Consulta desde tu CV web",
+        body: "Hola Gaspar, me gustaría contactarte por..."
+      }
+    },
+    footer: {
+      signature: "Hecho con React + Tailwind",
+      contact: "Contacto",
+      github: "GitHub"
+    }
+  },
+  en: {
+    nav: {
+      links: [
+        { href: sectionAnchors.about, label: "About" },
+        { href: sectionAnchors.projects, label: "Projects" },
+        { href: sectionAnchors.experience, label: "Experience" },
+        { href: sectionAnchors.contact, label: "Contact" }
+      ],
+      download: {
+        idle: "Download résumé",
+        loading: "Preparing résumé..."
+      },
+      menuLabel: "Menu",
+      openMenuAria: "Open navigation menu",
+      closeMenuAria: "Close navigation menu",
+      exploreTitle: "Explore",
+      languageSwitcherLabel: "Change language"
+    },
+    hero: {
+      badge: "Portfolio · Résumé",
+      title: "AI-assisted product developer for tailored solutions",
+      description:
+        "Web engineer focused on e-commerce integrations. I bridge platforms such as Tiendanube and WooCommerce with purpose-built experiences that elevate the customer journey.",
+      primaryCta: "View projects",
+      secondaryCta: "GitHub",
+      highlights: [
+        "Integrations & Automation",
+        "Custom commerce builds",
+        "User-centred experiences"
+      ],
+      avatarFallback: "Your photo"
+    },
+    about: {
+      heading: "About",
+      description:
+        "I am a software developer specialised in the web ecosystem with a strong focus on integrations and commerce. Every build is co-created with AI tooling. As a Tiendanube technology partner I ship plugins and integrations that connect platforms, automate operations, and improve customer experience end to end.",
+      skills: ["JavaScript", "TypeScript", "React", "Node.js", "Express", "Python", "PHP", "WooCommerce"]
+    },
+    projects: {
+      heading: "Projects",
+      subtitle: "Selected integrations, plugins, and automation tools that drive measurable impact.",
+      viewMore: "See more on GitHub →"
+    },
+    experience: {
+      heading: "Experience"
+    },
+    contact: {
+      heading: "Contact",
+      description: "Working on an integration, automation, or custom build? Let’s design the right solution together.",
+      button: "Email me",
+      note: "Download my résumé from the main menu",
+      form: {
+        name: "Your name",
+        email: "Your email",
+        message: "Your message",
+        submit: "Send message",
+        subject: "Enquiry from your online résumé",
+        body: "Hi Gaspar, I’d like to connect regarding..."
+      }
+    },
+    footer: {
+      signature: "Built with React + Tailwind",
+      contact: "Contact",
+      github: "GitHub"
+    }
+  }
+};

--- a/src/sections/About.tsx
+++ b/src/sections/About.tsx
@@ -1,26 +1,29 @@
+import { useLanguage } from "../hooks/useLanguage";
+
 export default function About() {
+  const { content } = useLanguage();
+  const aboutCopy = content.about;
+
   return (
     <section id="sobre-mi" className="scroll-mt-24 py-20">
       <div>
         <h2 className="text-3xl font-bold md:text-4xl">
           <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
-            Sobre mí
+            {aboutCopy.heading}
           </span>
         </h2>
         <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-transparent" />
       </div>
       <p className="mt-6 max-w-3xl text-base leading-relaxed text-white/70 md:text-lg">
-        Soy desarrollador de software con experiencia en entorno web con foco en <strong className="text-[#f1f5f9]">integraciones y e-commerce</strong>. Todos mis desarrollos son creados mediante IA. Trabajo como
-        partner tecnológico de <strong className="text-[#f1f5f9]">Tiendanube</strong> y desarrollo plugins e integraciones que conectan
-        plataformas, automatizan procesos y mejoran la experiencia de usuario.
+        {aboutCopy.description}
       </p>
       <ul className="mt-8 flex flex-wrap gap-2 text-sm text-white/70">
-        {["JavaScript", "TypeScript", "React", "Node.js", "Express", "Python", "PHP", "WooCommerce"].map((t) => (
+        {aboutCopy.skills.map((skill) => (
           <li
-            key={t}
+            key={skill}
             className="rounded-full border border-[#22d3ee]/30 bg-[#22d3ee]/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#f1f5f9]"
           >
-            {t}
+            {skill}
           </li>
         ))}
       </ul>

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -1,7 +1,11 @@
+import { useLanguage } from "../hooks/useLanguage";
+
 export default function Contact() {
+  const { content } = useLanguage();
+  const contactCopy = content.contact;
   const email = "tu-email@ejemplo.com"; // TODO: reemplazar
-  const subject = encodeURIComponent("Consulta desde tu CV web");
-  const body = encodeURIComponent("Hola Gaspar, me gustaría contactarte por...");
+  const subject = encodeURIComponent(contactCopy.form.subject);
+  const body = encodeURIComponent(contactCopy.form.body);
   const mailto = `mailto:${email}?subject=${subject}&body=${body}`;
 
   return (
@@ -11,21 +15,19 @@ export default function Contact() {
           <div>
             <h2 className="text-3xl font-bold md:text-4xl">
               <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
-                Contacto
+                {contactCopy.heading}
               </span>
             </h2>
             <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#22d3ee] to-transparent" />
           </div>
-          <p className="text-base text-white/70 md:text-lg">
-            ¿Tenés un proyecto, integración o idea en mente? Hablemos y diseñemos una solución a medida.
-          </p>
+          <p className="text-base text-white/70 md:text-lg">{contactCopy.description}</p>
           <a
             href={mailto}
             className="inline-flex w-fit items-center gap-2 rounded-full bg-[#22d3ee] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_18px_48px_rgba(34,211,238,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[#22d3ee]/90"
           >
-            Escribime por mail
+            {contactCopy.button}
           </a>
-          <p className="text-xs uppercase tracking-[0.3em] text-white/40">Descargá mi CV desde el menú principal</p>
+          <p className="text-xs uppercase tracking-[0.3em] text-white/40">{contactCopy.note}</p>
         </div>
         <div className="relative rounded-3xl border border-white/10 bg-[rgba(15,23,42,0.8)] p-6 shadow-[0_30px_80px_rgba(15,23,42,0.55)]">
           <div className="pointer-events-none absolute -right-6 -top-6 h-24 w-24 rounded-full bg-[#ec4899]/25 blur-3xl" />
@@ -38,21 +40,21 @@ export default function Contact() {
           >
             <input
               className="w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#22d3ee] focus:outline-none focus:ring-2 focus:ring-[#22d3ee]/40"
-              placeholder="Tu nombre"
+              placeholder={contactCopy.form.name}
             />
             <input
               className="w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#22d3ee] focus:outline-none focus:ring-2 focus:ring-[#22d3ee]/40"
-              placeholder="Tu email"
+              placeholder={contactCopy.form.email}
               type="email"
             />
             <textarea
               className="h-32 w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#ec4899] focus:outline-none focus:ring-2 focus:ring-[#ec4899]/30"
-              placeholder="Tu mensaje"
+              placeholder={contactCopy.form.message}
             />
             <button
               className="w-full rounded-full bg-[#ec4899] px-4 py-3 text-sm font-semibold text-[#0f172a] transition-transform hover:-translate-y-0.5 hover:bg-[#ec4899]/90"
             >
-              Enviar mensaje
+              {contactCopy.form.submit}
             </button>
           </form>
         </div>

--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -1,12 +1,15 @@
 import type { Job } from "../data/experience";
+import { useLanguage } from "../hooks/useLanguage";
 
 export default function Experience({ items }: { items: Job[] }) {
+  const { content } = useLanguage();
+
   return (
     <section id="experiencia" className="scroll-mt-24 py-20">
       <div>
         <h2 className="text-3xl font-bold md:text-4xl">
           <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
-            Experiencia
+            {content.experience.heading}
           </span>
         </h2>
         <div className="mt-3 h-[3px] w-28 rounded-full bg-gradient-to-r from-[#6366f1] to-transparent" />

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -1,5 +1,7 @@
 import type { CSSProperties } from "react";
 
+import { useLanguage } from "../hooks/useLanguage";
+
 // Define aquí la ruta de la imagen (por ejemplo, "/hero-photo.png") una vez que la subas manualmente
 const heroAvatarImage = new URL("../pic_01.png", import.meta.url).href
 
@@ -8,6 +10,8 @@ export default function Hero() {
   const heroAvatarStyles = hasAvatarImage
     ? ({ "--hero-avatar-image": `url(${heroAvatarImage})` } as CSSProperties)
     : undefined;
+  const { content } = useLanguage();
+  const heroCopy = content.hero;
 
   return (
     <section className="relative pt-20 md:pt-24">
@@ -19,25 +23,21 @@ export default function Hero() {
             <div className="relative grid items-center gap-12 md:grid-cols-[minmax(0,1fr)_minmax(220px,320px)]">
               <div className="space-y-6 text-left">
                 <span className="inline-flex items-center gap-2 rounded-full border border-[#22d3ee]/40 bg-[#22d3ee]/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-[#22d3ee]">
-                  Portfolio · CV
+                  {heroCopy.badge}
                 </span>
                 <h1 className="text-4xl font-extrabold leading-tight md:text-6xl">
                   <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
                     Gaspar Rambo
                   </span>
                 </h1>
-                <p className="text-xl font-semibold text-white/80 md:text-2xl">
-                  Desarrollador de soluciones a medida impulsadas por IA
-                </p>
-                <p className="max-w-xl text-lg text-white/70 md:text-xl">
-                  Desarrollador web especializado en integraciones para e-commerce. Conecto plataformas como Tiendanube y WooCommerce con soluciones para mejorar la experiencia de usuario.
-                </p>
+                <p className="text-xl font-semibold text-white/80 md:text-2xl">{heroCopy.title}</p>
+                <p className="max-w-xl text-lg text-white/70 md:text-xl">{heroCopy.description}</p>
                 <div className="flex flex-wrap gap-4">
                   <a
                     href="#proyectos"
                     className="rounded-full bg-[#ec4899] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_20px_60px_rgba(236,72,153,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[#ec4899]/90"
                   >
-                    Ver proyectos
+                    {heroCopy.primaryCta}
                   </a>
                   <a
                     href="https://github.com/RamboGM"
@@ -45,22 +45,20 @@ export default function Hero() {
                     className="rounded-full border border-[#6366f1]/60 px-6 py-2.5 text-sm font-semibold text-white/80 transition-all hover:-translate-y-0.5 hover:border-[#22d3ee]/80 hover:text-[#f1f5f9]"
                     rel="noopener"
                   >
-                    GitHub
+                    {heroCopy.secondaryCta}
                   </a>
                 </div>
                 <div className="flex flex-wrap gap-6 text-sm text-white/60">
-                  <div className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-[#22d3ee]" />
-                    Integraciones & Automatizaciones
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-[#ec4899]" />
-                    E-commerce a medida
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-[#6366f1]" />
-                    Experiencias centradas en el usuario
-                  </div>
+                  {heroCopy.highlights.map((item, index) => (
+                    <div key={item} className="flex items-center gap-2">
+                      <span
+                        className={`h-2 w-2 rounded-full ${
+                          ["bg-[#22d3ee]", "bg-[#ec4899]", "bg-[#6366f1]"][index] ?? "bg-[#22d3ee]"
+                        }`}
+                      />
+                      {item}
+                    </div>
+                  ))}
                 </div>
               </div>
               <div className="mx-auto w-48 sm:w-56 md:w-full">
@@ -70,7 +68,7 @@ export default function Hero() {
                       className={`hero-avatar${hasAvatarImage ? " hero-avatar--with-image" : ""}`}
                       style={heroAvatarStyles}
                     >
-                      <span>Tu foto</span>
+                      <span>{heroCopy.avatarFallback}</span>
                     </div>
                   </div>
                 </div>

--- a/src/sections/Projects.tsx
+++ b/src/sections/Projects.tsx
@@ -1,4 +1,5 @@
 import type { Project } from "../data/projects";
+import { useLanguage } from "../hooks/useLanguage";
 
 function ProjectCard({ p }: { p: Project }) {
   return (
@@ -40,18 +41,19 @@ function ProjectCard({ p }: { p: Project }) {
 }
 
 export default function Projects({ items }: { items: Project[] }) {
+  const { content } = useLanguage();
+  const projectsCopy = content.projects;
+
   return (
     <section id="proyectos" className="scroll-mt-24 py-20">
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
           <h2 className="text-3xl font-bold md:text-4xl">
             <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
-              Proyectos
+              {projectsCopy.heading}
             </span>
           </h2>
-          <p className="mt-2 text-sm text-white/60 md:text-base">
-            Selección de integraciones, plugins y automatizaciones que impulsan resultados.
-          </p>
+          <p className="mt-2 text-sm text-white/60 md:text-base">{projectsCopy.subtitle}</p>
         </div>
         <a
           href="https://github.com/RamboGM"
@@ -59,7 +61,7 @@ export default function Projects({ items }: { items: Project[] }) {
           className="text-sm font-medium text-white/70 transition-colors hover:text-[#22d3ee]"
           rel="noopener"
         >
-          Ver más en GitHub →
+          {projectsCopy.viewMore}
         </a>
       </div>
       <div className="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -1,0 +1,1 @@
+export type Language = "es" | "en";


### PR DESCRIPTION
## Summary
- introduce a language provider, shared hook, and translation catalog to enable Spanish and English content
- update navigation and all sections to consume the localized copy and add an EN/ES toggle without page reloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5d61e5bac83329ba0fdd70fb4ad0b