### PR TITLE
Fix html2canvas color parsing and localize CV filename

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,7 +4,7 @@ import { useLanguage } from "../hooks/useLanguage";
 import type { Language } from "../types/language";
 
 type NavbarProps = {
-  onDownloadCv?: () => Promise<void> | void;
+  onDownloadCv?: (language: Language) => Promise<void> | void;
 };
 
 const AVAILABLE_LANGUAGES: Language[] = ["en", "es"];
@@ -42,7 +42,7 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
     setIsDownloading(true);
 
     try {
-      await onDownloadCv();
+      await onDownloadCv(language);
     } finally {
       setIsDownloading(false);
     }


### PR DESCRIPTION
## Summary
- sanitize both stylesheet and inline styles to strip unsupported color functions before generating the PDF
- resolve html2canvas parsing errors by resolving fallback colors and reusing them in cloned documents
- generate language-specific resume filenames when exporting the PDF and pass the active language through the navbar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d827693564833283204e2fba37a0cb