### PR TITLE
Replace Tailwind color-mix utilities with RGBA values

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,8 +5,8 @@ export default function Footer() {
   const footerCopy = content.footer;
 
   return (
-    <footer className="mt-20 border-t border-white/10">
-      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-4 py-8 text-sm text-white/60 md:flex-row">
+    <footer className="mt-20 border-t border-[rgba(255,255,255,0.1)]">
+      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-4 py-8 text-sm text-[rgba(255,255,255,0.6)] md:flex-row">
         <p>© {new Date().getFullYear()} Gaspar Rambo — {footerCopy.signature}</p>
         <div className="flex items-center gap-4">
           <a className="transition-colors hover:text-[#22d3ee]" href="#contacto">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -61,7 +61,7 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
               }
             }}
             className={`transition-colors ${
-              language === code ? "text-[#22d3ee]" : "hover:text-white/80"
+              language === code ? "text-[#22d3ee]" : "hover:text-[rgba(255,255,255,0.8)]"
             }`}
           >
             {code.toUpperCase()}
@@ -72,37 +72,42 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
   );
 
   return (
-    <header className="sticky top-0 z-50 border-b border-white/10 bg-[rgba(15,23,42,0.85)] backdrop-blur">
+    <header className="sticky top-0 z-50 border-b border-[rgba(255,255,255,0.1)] bg-[rgba(15,23,42,0.85)] backdrop-blur">
       <nav className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
         <a href="#" className="relative flex items-center gap-3">
           <span className="relative flex h-11 w-11 items-center justify-center overflow-hidden rounded-2xl">
             <span className="absolute inset-0 rounded-2xl bg-gradient-to-br from-[#22d3ee] via-[#6366f1] to-[#ec4899] opacity-90" />
             <span
               aria-hidden="true"
-              className="absolute -inset-[18px] rounded-[32px] bg-gradient-to-br from-[#22d3ee]/30 via-[#6366f1]/20 to-transparent blur-2xl"
+              className="absolute -inset-[18px] rounded-[32px] bg-gradient-to-br from-[rgba(34,211,238,0.3)] via-[rgba(99,102,241,0.2)] to-transparent blur-2xl"
             />
-            <span className="absolute inset-[2px] rounded-[18px] bg-[#0f172a]/90" />
+            <span className="absolute inset-[2px] rounded-[18px] bg-[rgba(15,23,42,0.9)]" />
             <span className="relative text-base font-semibold tracking-[0.2em] text-[#e0f2fe]">GR</span>
           </span>
           <div className="leading-tight">
-            <span className="text-[11px] uppercase tracking-[0.5em] text-[#38bdf8]/70">Portfolio</span>
+            <span className="text-[11px] uppercase tracking-[0.5em] text-[rgba(56,189,248,0.7)]">Portfolio</span>
             <span className="block text-lg font-semibold text-white">Gaspar Rambo</span>
           </div>
         </a>
 
-        <ul className="hidden items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-sm text-white/70 shadow-[0_18px_40px_rgba(56,189,248,0.25)] backdrop-blur md:flex">
+        <ul className="hidden items-center gap-2 rounded-full border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.05)] px-2 py-1 text-sm text-[rgba(255,255,255,0.7)] shadow-[0_18px_40px_rgba(56,189,248,0.25)] backdrop-blur md:flex">
           {navigationLinks.map((item) => (
             <li key={item.href}>
               <a
                 className="group relative inline-flex items-center overflow-hidden rounded-full px-4 py-2 font-medium transition-colors duration-300 hover:text-white"
                 href={item.href}
               >
-                <span className="absolute inset-0 scale-75 rounded-full bg-gradient-to-r from-[#22d3ee]/10 via-[#6366f1]/10 to-transparent opacity-0 transition-all duration-300 group-hover:scale-100 group-hover:opacity-100" />
+                <span className="absolute inset-0 scale-75 rounded-full bg-gradient-to-r from-[rgba(34,211,238,0.1)] via-[rgba(99,102,241,0.1)] to-transparent opacity-0 transition-all duration-300 group-hover:scale-100 group-hover:opacity-100" />
                 <span className="relative">{item.label}</span>
               </a>
             </li>
           ))}
-          <li>{renderLanguageSwitcher("flex items-center gap-1 rounded-full border border-white/10 bg-[#0f172a]/40 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-white/60", "text-white/30")}</li>
+          <li>
+            {renderLanguageSwitcher(
+              "flex items-center gap-1 rounded-full border border-[rgba(255,255,255,0.1)] bg-[rgba(15,23,42,0.4)] px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-[rgba(255,255,255,0.6)]",
+              "text-[rgba(255,255,255,0.3)]",
+            )}
+          </li>
           <li>
             <button
               type="button"
@@ -120,7 +125,7 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
         <button
           type="button"
           onClick={toggleMenu}
-          className="relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-[#38bdf8] via-[#818cf8] to-[#f472b6] text-slate-900 shadow-[0_18px_40px_rgba(56,189,248,0.4)] transition-transform duration-300 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-[#38bdf8]/60 focus:ring-offset-2 focus:ring-offset-[#0f172a] md:hidden"
+          className="relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-[#38bdf8] via-[#818cf8] to-[#f472b6] text-slate-900 shadow-[0_18px_40px_rgba(56,189,248,0.4)] transition-transform duration-300 hover:-translate-y-0.5 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(56,189,248,0.6)] md:hidden"
           aria-expanded={isMenuOpen}
           aria-label={isMenuOpen ? content.nav.closeMenuAria : content.nav.openMenuAria}
         >
@@ -152,36 +157,36 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
         } md:hidden`}
       >
         <div
-          className="absolute inset-0 bg-slate-950/60 backdrop-blur-sm"
+          className="absolute inset-0 bg-[rgba(2,6,23,0.6)] backdrop-blur-sm"
           onClick={handleNavigate}
           aria-hidden="true"
         />
         <div
-          className={`absolute right-4 top-24 w-[calc(100%-2rem)] max-w-xs origin-top-right overflow-hidden rounded-3xl border border-white/10 bg-[rgba(15,23,42,0.95)] p-6 shadow-[0_24px_60px_rgba(8,47,73,0.45)] transition-all duration-500 ${
+          className={`absolute right-4 top-24 w-[calc(100%-2rem)] max-w-xs origin-top-right overflow-hidden rounded-3xl border border-[rgba(255,255,255,0.1)] bg-[rgba(15,23,42,0.95)] p-6 shadow-[0_24px_60px_rgba(8,47,73,0.45)] transition-all duration-500 ${
             isMenuOpen ? "translate-y-0 scale-100 opacity-100" : "-translate-y-4 scale-95 opacity-0"
           }`}
         >
           <span
             aria-hidden="true"
-            className="absolute -top-20 -right-16 h-48 w-48 rounded-full bg-[#38bdf8]/40 blur-3xl"
+            className="absolute -top-20 -right-16 h-48 w-48 rounded-full bg-[rgba(56,189,248,0.4)] blur-3xl"
           />
           <span
             aria-hidden="true"
-            className="absolute -bottom-24 -left-12 h-52 w-52 rounded-full bg-[#f472b6]/30 blur-3xl"
+            className="absolute -bottom-24 -left-12 h-52 w-52 rounded-full bg-[rgba(244,114,182,0.3)] blur-3xl"
           />
           <div className="relative z-10">
             <div className="flex items-center justify-between gap-4">
-              <p className="text-xs uppercase tracking-[0.4em] text-white/50">{content.nav.exploreTitle}</p>
+              <p className="text-xs uppercase tracking-[0.4em] text-[rgba(255,255,255,0.5)]">{content.nav.exploreTitle}</p>
               {renderLanguageSwitcher(
-                "flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-white/60",
-                "text-white/30"
+                "flex items-center gap-1 rounded-full border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.05)] px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-[rgba(255,255,255,0.6)]",
+                "text-[rgba(255,255,255,0.3)]"
               )}
             </div>
             <ul className="mt-6 space-y-4">
               {navigationLinks.map((item) => (
                 <li key={item.href}>
                   <a
-                    className="group flex items-center justify-between rounded-2xl border border-white/5 bg-white/[0.04] px-4 py-3 text-base font-medium text-white/80 transition duration-300 hover:border-white/20 hover:bg-white/[0.08] hover:text-white"
+                    className="group flex items-center justify-between rounded-2xl border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.04)] px-4 py-3 text-base font-medium text-[rgba(255,255,255,0.8)] transition duration-300 hover:border-[rgba(255,255,255,0.2)] hover:bg-[rgba(255,255,255,0.08)] hover:text-white"
                     href={item.href}
                     onClick={handleNavigate}
                   >
@@ -192,7 +197,7 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
                       fill="none"
                       stroke="currentColor"
                       strokeWidth="1.5"
-                      className="h-4 w-4 -rotate-45 text-white/70 transition-transform duration-300 group-hover:translate-x-1 group-hover:-rotate-0"
+                      className="h-4 w-4 -rotate-45 text-[rgba(255,255,255,0.7)] transition-transform duration-300 group-hover:translate-x-1 group-hover:-rotate-0"
                     >
                       <path d="M5 12h14M13 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
                     </svg>

--- a/src/sections/About.tsx
+++ b/src/sections/About.tsx
@@ -14,14 +14,14 @@ export default function About() {
         </h2>
         <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-transparent" />
       </div>
-      <p className="mt-6 max-w-3xl text-base leading-relaxed text-white/70 md:text-lg">
+      <p className="mt-6 max-w-3xl text-base leading-relaxed text-[rgba(255,255,255,0.7)] md:text-lg">
         {aboutCopy.description}
       </p>
-      <ul className="mt-8 flex flex-wrap gap-2 text-sm text-white/70">
+      <ul className="mt-8 flex flex-wrap gap-2 text-sm text-[rgba(255,255,255,0.7)]">
         {aboutCopy.skills.map((skill) => (
           <li
             key={skill}
-            className="rounded-full border border-[#22d3ee]/30 bg-[#22d3ee]/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#f1f5f9]"
+            className="rounded-full border border-[rgba(34,211,238,0.3)] bg-[rgba(34,211,238,0.1)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#f1f5f9]"
           >
             {skill}
           </li>

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -20,17 +20,17 @@ export default function Contact() {
             </h2>
             <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#22d3ee] to-transparent" />
           </div>
-          <p className="text-base text-white/70 md:text-lg">{contactCopy.description}</p>
+          <p className="text-base text-[rgba(255,255,255,0.7)] md:text-lg">{contactCopy.description}</p>
           <a
             href={mailto}
-            className="inline-flex w-fit items-center gap-2 rounded-full bg-[#22d3ee] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_18px_48px_rgba(34,211,238,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[#22d3ee]/90"
+            className="inline-flex w-fit items-center gap-2 rounded-full bg-[#22d3ee] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_18px_48px_rgba(34,211,238,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[rgba(34,211,238,0.9)]"
           >
             {contactCopy.button}
           </a>
-          <p className="text-xs uppercase tracking-[0.3em] text-white/40">{contactCopy.note}</p>
+          <p className="text-xs uppercase tracking-[0.3em] text-[rgba(255,255,255,0.4)]">{contactCopy.note}</p>
         </div>
-        <div className="relative rounded-3xl border border-white/10 bg-[rgba(15,23,42,0.8)] p-6 shadow-[0_30px_80px_rgba(15,23,42,0.55)]">
-          <div className="pointer-events-none absolute -right-6 -top-6 h-24 w-24 rounded-full bg-[#ec4899]/25 blur-3xl" />
+        <div className="relative rounded-3xl border border-[rgba(255,255,255,0.1)] bg-[rgba(15,23,42,0.8)] p-6 shadow-[0_30px_80px_rgba(15,23,42,0.55)]">
+          <div className="pointer-events-none absolute -right-6 -top-6 h-24 w-24 rounded-full bg-[rgba(236,72,153,0.25)] blur-3xl" />
           <form
             onSubmit={(e) => {
               e.preventDefault();
@@ -39,20 +39,20 @@ export default function Contact() {
             className="relative space-y-4"
           >
             <input
-              className="w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#22d3ee] focus:outline-none focus:ring-2 focus:ring-[#22d3ee]/40"
+              className="w-full rounded-2xl border border-[rgba(255,255,255,0.1)] bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-[rgba(255,255,255,0.4)] focus:border-[#22d3ee] focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(34,211,238,0.4)]"
               placeholder={contactCopy.form.name}
             />
             <input
-              className="w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#22d3ee] focus:outline-none focus:ring-2 focus:ring-[#22d3ee]/40"
+              className="w-full rounded-2xl border border-[rgba(255,255,255,0.1)] bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-[rgba(255,255,255,0.4)] focus:border-[#22d3ee] focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(34,211,238,0.4)]"
               placeholder={contactCopy.form.email}
               type="email"
             />
             <textarea
-              className="h-32 w-full rounded-2xl border border-white/10 bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-white/40 focus:border-[#ec4899] focus:outline-none focus:ring-2 focus:ring-[#ec4899]/30"
+              className="h-32 w-full rounded-2xl border border-[rgba(255,255,255,0.1)] bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-[rgba(255,255,255,0.4)] focus:border-[#ec4899] focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(236,72,153,0.3)]"
               placeholder={contactCopy.form.message}
             />
             <button
-              className="w-full rounded-full bg-[#ec4899] px-4 py-3 text-sm font-semibold text-[#0f172a] transition-transform hover:-translate-y-0.5 hover:bg-[#ec4899]/90"
+              className="w-full rounded-full bg-[#ec4899] px-4 py-3 text-sm font-semibold text-[#0f172a] transition-transform hover:-translate-y-0.5 hover:bg-[rgba(236,72,153,0.9)]"
             >
               {contactCopy.form.submit}
             </button>

--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -14,27 +14,27 @@ export default function Experience({ items }: { items: Job[] }) {
         </h2>
         <div className="mt-3 h-[3px] w-28 rounded-full bg-gradient-to-r from-[#6366f1] to-transparent" />
       </div>
-      <ol className="relative mt-10 space-y-10 border-l border-white/10 pl-6">
+      <ol className="relative mt-10 space-y-10 border-l border-[rgba(255,255,255,0.1)] pl-6">
         {items.map((j, i) => (
           <li key={i} className="relative">
             <span className="absolute -left-6 top-2 block h-5 w-5 rounded-full bg-gradient-to-br from-[#ec4899] via-[#6366f1] to-[#22d3ee] shadow-[0_0_25px_rgba(99,102,241,0.4)]" />
             <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
               <div className="space-y-2">
                 <h3 className="text-lg font-semibold text-[#f1f5f9]">
-                  {j.role} · <span className="font-medium text-white/70">{j.company}</span>
+                  {j.role} · <span className="font-medium text-[rgba(255,255,255,0.7)]">{j.company}</span>
                 </h3>
-                <p className="text-sm text-white/70 md:text-base">{j.summary}</p>
+                <p className="text-sm text-[rgba(255,255,255,0.7)] md:text-base">{j.summary}</p>
                 {j.stack?.length ? (
-                  <ul className="mt-2 flex flex-wrap gap-2 text-xs text-white/60">
+                  <ul className="mt-2 flex flex-wrap gap-2 text-xs text-[rgba(255,255,255,0.6)]">
                     {j.stack.map((s) => (
-                      <li key={s} className="rounded-full border border-white/10 bg-[rgba(15,23,42,0.8)] px-2 py-0.5">
+                      <li key={s} className="rounded-full border border-[rgba(255,255,255,0.1)] bg-[rgba(15,23,42,0.8)] px-2 py-0.5">
                         {s}
                       </li>
                     ))}
                   </ul>
                 ) : null}
               </div>
-              <span className="text-xs font-medium uppercase tracking-widest text-white/50 md:text-sm">{j.period}</span>
+              <span className="text-xs font-medium uppercase tracking-widest text-[rgba(255,255,255,0.5)] md:text-sm">{j.period}</span>
             </div>
           </li>
         ))}

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -18,11 +18,11 @@ export default function Hero() {
       <div className="mt-16 md:mt-20">
         <div className="rounded-[2.75rem] bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] p-[1px] shadow-[0_40px_120px_rgba(34,211,238,0.18)]">
           <div className="relative overflow-hidden rounded-[2.7rem] bg-[rgba(15,23,42,0.85)] px-6 py-16 md:px-14 md:py-20">
-            <div className="absolute -left-24 -top-24 h-64 w-64 rounded-full bg-[#ec4899]/20 blur-3xl" aria-hidden="true" />
-            <div className="absolute -bottom-32 -right-16 h-72 w-72 rounded-full bg-[#22d3ee]/20 blur-[120px]" aria-hidden="true" />
+            <div className="absolute -left-24 -top-24 h-64 w-64 rounded-full bg-[rgba(236,72,153,0.2)] blur-3xl" aria-hidden="true" />
+            <div className="absolute -bottom-32 -right-16 h-72 w-72 rounded-full bg-[rgba(34,211,238,0.2)] blur-[120px]" aria-hidden="true" />
             <div className="relative grid items-center gap-12 md:grid-cols-[minmax(0,1fr)_minmax(220px,320px)]">
               <div className="space-y-6 text-left">
-                <span className="inline-flex items-center gap-2 rounded-full border border-[#22d3ee]/40 bg-[#22d3ee]/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-[#22d3ee]">
+                <span className="inline-flex items-center gap-2 rounded-full border border-[rgba(34,211,238,0.4)] bg-[rgba(34,211,238,0.1)] px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-[#22d3ee]">
                   {heroCopy.badge}
                 </span>
                 <h1 className="text-4xl font-extrabold leading-tight md:text-6xl">
@@ -30,25 +30,25 @@ export default function Hero() {
                     Gaspar Rambo
                   </span>
                 </h1>
-                <p className="text-xl font-semibold text-white/80 md:text-2xl">{heroCopy.title}</p>
-                <p className="max-w-xl text-lg text-white/70 md:text-xl">{heroCopy.description}</p>
+                <p className="text-xl font-semibold text-[rgba(255,255,255,0.8)] md:text-2xl">{heroCopy.title}</p>
+                <p className="max-w-xl text-lg text-[rgba(255,255,255,0.7)] md:text-xl">{heroCopy.description}</p>
                 <div className="flex flex-wrap gap-4">
                   <a
                     href="#proyectos"
-                    className="rounded-full bg-[#ec4899] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_20px_60px_rgba(236,72,153,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[#ec4899]/90"
+                    className="rounded-full bg-[#ec4899] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_20px_60px_rgba(236,72,153,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[rgba(236,72,153,0.9)]"
                   >
                     {heroCopy.primaryCta}
                   </a>
                   <a
                     href="https://github.com/RamboGM"
                     target="_blank"
-                    className="rounded-full border border-[#6366f1]/60 px-6 py-2.5 text-sm font-semibold text-white/80 transition-all hover:-translate-y-0.5 hover:border-[#22d3ee]/80 hover:text-[#f1f5f9]"
+                    className="rounded-full border border-[rgba(99,102,241,0.6)] px-6 py-2.5 text-sm font-semibold text-[rgba(255,255,255,0.8)] transition-all hover:-translate-y-0.5 hover:border-[rgba(34,211,238,0.8)] hover:text-[#f1f5f9]"
                     rel="noopener"
                   >
                     {heroCopy.secondaryCta}
                   </a>
                 </div>
-                <div className="flex flex-wrap gap-6 text-sm text-white/60">
+                <div className="flex flex-wrap gap-6 text-sm text-[rgba(255,255,255,0.6)]">
                   {heroCopy.highlights.map((item, index) => (
                     <div key={item} className="flex items-center gap-2">
                       <span

--- a/src/sections/Projects.tsx
+++ b/src/sections/Projects.tsx
@@ -3,13 +3,13 @@ import { useLanguage } from "../hooks/useLanguage";
 
 function ProjectCard({ p }: { p: Project }) {
   return (
-    <article className="group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm transition-all hover:border-[#22d3ee]/50 hover:bg-[#22d3ee]/10">
-      <div className="pointer-events-none absolute -right-10 top-1/3 h-32 w-32 rounded-full bg-[#6366f1]/20 blur-3xl transition-transform duration-700 ease-out group-hover:translate-x-3 group-hover:-translate-y-4" />
+    <article className="group relative overflow-hidden rounded-2xl border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.05)] p-6 backdrop-blur-sm transition-all hover:border-[rgba(34,211,238,0.5)] hover:bg-[rgba(34,211,238,0.1)]">
+      <div className="pointer-events-none absolute -right-10 top-1/3 h-32 w-32 rounded-full bg-[rgba(99,102,241,0.2)] blur-3xl transition-transform duration-700 ease-out group-hover:translate-x-3 group-hover:-translate-y-4" />
       <h3 className="text-lg font-semibold text-[#f1f5f9]">{p.title}</h3>
-      <p className="mt-2 text-sm text-white/70">{p.description}</p>
-      <ul className="mt-4 flex flex-wrap gap-2 text-xs text-white/60">
+      <p className="mt-2 text-sm text-[rgba(255,255,255,0.7)]">{p.description}</p>
+      <ul className="mt-4 flex flex-wrap gap-2 text-xs text-[rgba(255,255,255,0.6)]">
         {p.tech.map((t) => (
-          <li key={t} className="rounded-full border border-white/10 bg-[rgba(15,23,42,0.8)] px-2 py-0.5">
+          <li key={t} className="rounded-full border border-[rgba(255,255,255,0.1)] bg-[rgba(15,23,42,0.8)] px-2 py-0.5">
             {t}
           </li>
         ))}
@@ -19,7 +19,7 @@ function ProjectCard({ p }: { p: Project }) {
           <a
             href={p.repo}
             target="_blank"
-            className="font-medium text-[#22d3ee] transition-colors hover:text-[#22d3ee]/70"
+            className="font-medium text-[#22d3ee] transition-colors hover:text-[rgba(34,211,238,0.7)]"
             rel="noopener"
           >
             Repo
@@ -29,7 +29,7 @@ function ProjectCard({ p }: { p: Project }) {
           <a
             href={p.demo}
             target="_blank"
-            className="font-medium text-[#ec4899] transition-colors hover:text-[#ec4899]/80"
+            className="font-medium text-[#ec4899] transition-colors hover:text-[rgba(236,72,153,0.8)]"
             rel="noopener"
           >
             Demo
@@ -53,12 +53,12 @@ export default function Projects({ items }: { items: Project[] }) {
               {projectsCopy.heading}
             </span>
           </h2>
-          <p className="mt-2 text-sm text-white/60 md:text-base">{projectsCopy.subtitle}</p>
+          <p className="mt-2 text-sm text-[rgba(255,255,255,0.6)] md:text-base">{projectsCopy.subtitle}</p>
         </div>
         <a
           href="https://github.com/RamboGM"
           target="_blank"
-          className="text-sm font-medium text-white/70 transition-colors hover:text-[#22d3ee]"
+          className="text-sm font-medium text-[rgba(255,255,255,0.7)] transition-colors hover:text-[#22d3ee]"
           rel="noopener"
         >
           {projectsCopy.viewMore}


### PR DESCRIPTION
## Summary
- replace Tailwind color opacity utilities with explicit RGBA values so html2canvas no longer receives oklab/color-mix declarations
- update focus styles to use outline utilities without unsupported color functions while preserving the intended look across navbar and contact form

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d82f418538833299cbf9b09dbf17fc