### PR TITLE
Ensure generated PDF matches page content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -404,7 +404,7 @@ function AppContent({ pageRef, onDownloadCv }: AppContentProps) {
     >
       <ParticleBackground />
       <div className="relative z-10">
-        <Navbar onDownloadCv={onDownloadCv} />
+        <Navbar onDownloadCv={onDownloadCv} className="pdf-hide" />
         <main className="mx-auto max-w-6xl px-4">
           <Hero />
           <About />
@@ -412,7 +412,7 @@ function AppContent({ pageRef, onDownloadCv }: AppContentProps) {
           <Experience items={jobsByLanguage[language]} />
           <Contact />
         </main>
-        <Footer />
+        <Footer className="pdf-hide" />
       </div>
     </div>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,11 +1,15 @@
 import { useLanguage } from "../hooks/useLanguage";
 
-export default function Footer() {
+type FooterProps = {
+  className?: string;
+};
+
+export default function Footer({ className = "" }: FooterProps) {
   const { content } = useLanguage();
   const footerCopy = content.footer;
 
   return (
-    <footer className="mt-20 border-t border-[rgba(255,255,255,0.1)]">
+    <footer className={`mt-20 border-t border-[rgba(255,255,255,0.1)] ${className}`.trim()}>
       <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-4 py-8 text-sm text-[rgba(255,255,255,0.6)] md:flex-row">
         <p>© {new Date().getFullYear()} Gaspar Rambo — {footerCopy.signature}</p>
         <div className="flex items-center gap-4">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,11 +5,12 @@ import type { Language } from "../types/language";
 
 type NavbarProps = {
   onDownloadCv?: (language: Language) => Promise<void> | void;
+  className?: string;
 };
 
 const AVAILABLE_LANGUAGES: Language[] = ["en", "es"];
 
-export default function Navbar({ onDownloadCv }: NavbarProps) {
+export default function Navbar({ onDownloadCv, className = "" }: NavbarProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const { content, language, setLanguage } = useLanguage();
@@ -72,7 +73,9 @@ export default function Navbar({ onDownloadCv }: NavbarProps) {
   );
 
   return (
-    <header className="sticky top-0 z-50 border-b border-[rgba(255,255,255,0.1)] bg-[rgba(15,23,42,0.85)] backdrop-blur">
+    <header
+      className={`sticky top-0 z-50 border-b border-[rgba(255,255,255,0.1)] bg-[rgba(15,23,42,0.85)] backdrop-blur ${className}`.trim()}
+    >
       <nav className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
         <a href="#" className="relative flex items-center gap-3">
           <span className="relative flex h-11 w-11 items-center justify-center overflow-hidden rounded-2xl">

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,7 @@ body {
 [data-pdf-root].pdf-export {
   position: relative;
   isolation: isolate;
+  overflow: visible !important;
 }
 
 [data-pdf-root].pdf-export::before,


### PR DESCRIPTION
## Summary
- allow the navigation bar and footer to receive extra classes so they can be excluded from PDF exports
- hide header/footer during PDF generation to mirror the visible page content without chrome
- force the cloned PDF root to allow overflow so the full page content is captured

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e18aa5a60c8332bf3965d7531b6983