### PR TITLE
Add education section and align contact styling

### DIFF
--- a/public/analitico.pdf
+++ b/public/analitico.pdf
@@ -1,0 +1,33 @@
+%PDF-1.4
+%
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 68 >>
+stream
+BT /F1 24 Tf 72 720 Td (Analítico pendiente de actualizar) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000056 00000 n 
+0000000116 00000 n 
+0000000259 00000 n 
+0000000380 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+470
+%%EOF

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import type { Language } from "./types/language";
 import Navbar from "./components/Navbar";
 import Hero from "./sections/Hero";
 import About from "./sections/About";
+import Education from "./sections/Education";
 import Projects from "./sections/Projects";
 import Experience from "./sections/Experience";
 import Contact from "./sections/Contact";
@@ -463,10 +464,11 @@ function AppContent({ pageRef, onDownloadCv }: AppContentProps) {
         <Navbar onDownloadCv={onDownloadCv} className="pdf-hide" />
         <main className="mx-auto max-w-6xl px-4">
           <Hero />
+          <Contact />
           <About />
+          <Education />
           <Projects items={projectsByLanguage[language]} />
           <Experience items={jobsByLanguage[language]} />
-          <Contact />
         </main>
         <Footer className="pdf-hide" />
       </div>

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -44,19 +44,30 @@ interface ExperienceTranslation {
   heading: string;
 }
 
+interface ContactDetailTranslation {
+  label: string;
+  value: string;
+  href?: string;
+}
+
 interface ContactTranslation {
   heading: string;
   description: string;
   button: string;
   note: string;
-  form: {
-    name: string;
-    email: string;
-    message: string;
-    submit: string;
-    subject: string;
-    body: string;
-  };
+  email: string;
+  mailSubject: string;
+  mailBody: string;
+  details: ContactDetailTranslation[];
+}
+
+interface EducationTranslation {
+  heading: string;
+  description: string;
+  highlights: string[];
+  transcriptCta: string;
+  transcriptLink: string;
+  transcriptNote?: string;
 }
 
 interface FooterTranslation {
@@ -72,11 +83,13 @@ export interface Translation {
   projects: ProjectsTranslation;
   experience: ExperienceTranslation;
   contact: ContactTranslation;
+  education: EducationTranslation;
   footer: FooterTranslation;
 }
 
 const sectionAnchors = {
   about: "#sobre-mi",
+  education: "#formacion-academica",
   projects: "#proyectos",
   experience: "#experiencia",
   contact: "#contacto"
@@ -86,10 +99,11 @@ export const translations: Record<Language, Translation> = {
   es: {
     nav: {
       links: [
+        { href: sectionAnchors.contact, label: "Contacto" },
         { href: sectionAnchors.about, label: "Sobre mí" },
+        { href: sectionAnchors.education, label: "Formación académica" },
         { href: sectionAnchors.projects, label: "Proyectos" },
-        { href: sectionAnchors.experience, label: "Experiencia" },
-        { href: sectionAnchors.contact, label: "Contacto" }
+        { href: sectionAnchors.experience, label: "Experiencia" }
       ],
       download: {
         idle: "Descargar CV",
@@ -130,18 +144,42 @@ export const translations: Record<Language, Translation> = {
       heading: "Experiencia"
     },
     contact: {
-      heading: "Contacto",
-      description: "¿Tenés un proyecto, integración o idea en mente? Hablemos y diseñemos una solución a medida.",
+      heading: "Información de contacto",
+      description:
+        "¿Tenés un proyecto, integración o idea en mente? Hablemos y diseñemos una solución a medida.",
       button: "Escribime por mail",
-      note: "Descargá mi CV desde el menú principal",
-      form: {
-        name: "Tu nombre",
-        email: "Tu email",
-        message: "Tu mensaje",
-        submit: "Enviar mensaje",
-        subject: "Consulta desde tu CV web",
-        body: "Hola Gaspar, me gustaría contactarte por..."
-      }
+      note: "Actualizá los datos de contacto según tus canales preferidos.",
+      email: "tu-email@ejemplo.com",
+      mailSubject: "Consulta desde tu CV web",
+      mailBody: "Hola Gaspar, me gustaría contactarte por...",
+      details: [
+        {
+          label: "Email",
+          value: "tu-email@ejemplo.com",
+          href: "mailto:tu-email@ejemplo.com"
+        },
+        {
+          label: "LinkedIn",
+          value: "linkedin.com/in/tu-usuario",
+          href: "https://www.linkedin.com/in/tu-usuario"
+        },
+        {
+          label: "Ubicación",
+          value: "Argentina"
+        }
+      ]
+    },
+    education: {
+      heading: "Formación académica",
+      description:
+        "Trayectoria educativa enfocada en el desarrollo de software, automatización y soluciones impulsadas por IA para e-commerce.",
+      highlights: [
+        "Programas intensivos de desarrollo web orientados a integraciones y automatización",
+        "Capacitación continua en herramientas IA aplicadas a experiencias digitales"
+      ],
+      transcriptCta: "Descargar analítico",
+      transcriptLink: "/analitico.pdf",
+      transcriptNote: "Actualizá el archivo con tu analítico oficial."
     },
     footer: {
       signature: "Hecho con React + Tailwind",
@@ -152,10 +190,11 @@ export const translations: Record<Language, Translation> = {
   en: {
     nav: {
       links: [
+        { href: sectionAnchors.contact, label: "Contact info" },
         { href: sectionAnchors.about, label: "About" },
+        { href: sectionAnchors.education, label: "Education" },
         { href: sectionAnchors.projects, label: "Projects" },
-        { href: sectionAnchors.experience, label: "Experience" },
-        { href: sectionAnchors.contact, label: "Contact" }
+        { href: sectionAnchors.experience, label: "Experience" }
       ],
       download: {
         idle: "Download résumé",
@@ -196,18 +235,42 @@ export const translations: Record<Language, Translation> = {
       heading: "Experience"
     },
     contact: {
-      heading: "Contact",
-      description: "Working on an integration, automation, or custom build? Let’s design the right solution together.",
+      heading: "Contact information",
+      description:
+        "Working on an integration, automation, or custom build? Let’s design the right solution together.",
       button: "Email me",
-      note: "Download my résumé from the main menu",
-      form: {
-        name: "Your name",
-        email: "Your email",
-        message: "Your message",
-        submit: "Send message",
-        subject: "Enquiry from your online résumé",
-        body: "Hi Gaspar, I’d like to connect regarding..."
-      }
+      note: "Update these details with your preferred contact channels.",
+      email: "your-email@example.com",
+      mailSubject: "Enquiry from your online résumé",
+      mailBody: "Hi Gaspar, I’d like to connect regarding...",
+      details: [
+        {
+          label: "Email",
+          value: "your-email@example.com",
+          href: "mailto:your-email@example.com"
+        },
+        {
+          label: "LinkedIn",
+          value: "linkedin.com/in/your-handle",
+          href: "https://www.linkedin.com/in/your-handle"
+        },
+        {
+          label: "Location",
+          value: "Argentina"
+        }
+      ]
+    },
+    education: {
+      heading: "Education",
+      description:
+        "Learning path focused on software development, automation, and AI-assisted experiences for commerce.",
+      highlights: [
+        "Intensive web development programmes specialising in integrations and automation",
+        "Continuous upskilling with AI tooling tailored to digital product delivery"
+      ],
+      transcriptCta: "Download transcript",
+      transcriptLink: "/analitico.pdf",
+      transcriptNote: "Replace the file with your official academic record."
     },
     footer: {
       signature: "Built with React + Tailwind",

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -1,64 +1,60 @@
 import { useLanguage } from "../hooks/useLanguage";
 
+const primaryButtonClasses =
+  "rounded-full bg-[#ec4899] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_20px_60px_rgba(236,72,153,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[rgba(236,72,153,0.9)]";
+
 export default function Contact() {
   const { content } = useLanguage();
   const contactCopy = content.contact;
-  const email = "tu-email@ejemplo.com"; // TODO: reemplazar
-  const subject = encodeURIComponent(contactCopy.form.subject);
-  const body = encodeURIComponent(contactCopy.form.body);
-  const mailto = `mailto:${email}?subject=${subject}&body=${body}`;
+  const subject = encodeURIComponent(contactCopy.mailSubject);
+  const body = encodeURIComponent(contactCopy.mailBody);
+  const mailto = `mailto:${contactCopy.email}?subject=${subject}&body=${body}`;
+
+  const details = contactCopy.details.length
+    ? contactCopy.details
+    : [
+        {
+          label: "Email",
+          value: contactCopy.email,
+          href: `mailto:${contactCopy.email}`,
+        },
+      ];
 
   return (
     <section id="contacto" className="scroll-mt-24 py-20">
-      <div className="grid items-center gap-10 md:grid-cols-2">
-        <div className="space-y-6">
-          <div>
-            <h2 className="text-3xl font-bold md:text-4xl">
-              <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
-                {contactCopy.heading}
-              </span>
-            </h2>
-            <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#22d3ee] to-transparent" />
-          </div>
-          <p className="text-base text-[rgba(255,255,255,0.7)] md:text-lg">{contactCopy.description}</p>
-          <a
-            href={mailto}
-            className="inline-flex w-fit items-center gap-2 rounded-full bg-[#22d3ee] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_18px_48px_rgba(34,211,238,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[rgba(34,211,238,0.9)]"
-          >
-            {contactCopy.button}
-          </a>
-          <p className="text-xs uppercase tracking-[0.3em] text-[rgba(255,255,255,0.4)]">{contactCopy.note}</p>
-        </div>
-        <div className="relative rounded-3xl border border-[rgba(255,255,255,0.1)] bg-[rgba(15,23,42,0.8)] p-6 shadow-[0_30px_80px_rgba(15,23,42,0.55)]">
-          <div className="pointer-events-none absolute -right-6 -top-6 h-24 w-24 rounded-full bg-[rgba(236,72,153,0.25)] blur-3xl" />
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              window.location.href = mailto;
-            }}
-            className="relative space-y-4"
-          >
-            <input
-              className="w-full rounded-2xl border border-[rgba(255,255,255,0.1)] bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-[rgba(255,255,255,0.4)] focus:border-[#22d3ee] focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(34,211,238,0.4)]"
-              placeholder={contactCopy.form.name}
-            />
-            <input
-              className="w-full rounded-2xl border border-[rgba(255,255,255,0.1)] bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-[rgba(255,255,255,0.4)] focus:border-[#22d3ee] focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(34,211,238,0.4)]"
-              placeholder={contactCopy.form.email}
-              type="email"
-            />
-            <textarea
-              className="h-32 w-full rounded-2xl border border-[rgba(255,255,255,0.1)] bg-[rgba(11,20,37,0.8)] px-4 py-3 text-sm text-[#f1f5f9] placeholder:text-[rgba(255,255,255,0.4)] focus:border-[#ec4899] focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(236,72,153,0.3)]"
-              placeholder={contactCopy.form.message}
-            />
-            <button
-              className="w-full rounded-full bg-[#ec4899] px-4 py-3 text-sm font-semibold text-[#0f172a] transition-transform hover:-translate-y-0.5 hover:bg-[rgba(236,72,153,0.9)]"
-            >
-              {contactCopy.form.submit}
-            </button>
-          </form>
-        </div>
+      <div>
+        <h2 className="text-3xl font-bold md:text-4xl">
+          <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+            {contactCopy.heading}
+          </span>
+        </h2>
+        <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-transparent" />
       </div>
+      <p className="mt-6 max-w-3xl text-base leading-relaxed text-[rgba(255,255,255,0.7)] md:text-lg">
+        {contactCopy.description}
+      </p>
+      <ul className="mt-8 flex flex-wrap gap-2 text-sm text-[rgba(255,255,255,0.7)]">
+        {details.map((detail) => (
+          <li
+            key={`${detail.label}-${detail.value}`}
+            className="rounded-full border border-[rgba(34,211,238,0.3)] bg-[rgba(34,211,238,0.1)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#f1f5f9]"
+          >
+            {detail.href ? (
+              <a href={detail.href} className="transition-colors hover:text-[rgba(255,255,255,0.8)]">
+                <span className="font-semibold text-[#22d3ee]">{detail.label}:</span> {detail.value}
+              </a>
+            ) : (
+              <span>
+                <span className="font-semibold text-[#22d3ee]">{detail.label}:</span> {detail.value}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+      <a href={mailto} className={`mt-8 inline-flex items-center gap-2 ${primaryButtonClasses}`}>
+        {contactCopy.button}
+      </a>
+      <p className="mt-4 text-xs uppercase tracking-[0.3em] text-[rgba(255,255,255,0.4)]">{contactCopy.note}</p>
     </section>
   );
 }

--- a/src/sections/Education.tsx
+++ b/src/sections/Education.tsx
@@ -1,0 +1,51 @@
+import { useLanguage } from "../hooks/useLanguage";
+
+const primaryButtonClasses =
+  "rounded-full bg-[#ec4899] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_20px_60px_rgba(236,72,153,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[rgba(236,72,153,0.9)]";
+
+export default function Education() {
+  const { content } = useLanguage();
+  const educationCopy = content.education;
+
+  return (
+    <section id="formacion-academica" className="scroll-mt-24 py-20">
+      <div>
+        <h2 className="text-3xl font-bold md:text-4xl">
+          <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+            {educationCopy.heading}
+          </span>
+        </h2>
+        <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-transparent" />
+      </div>
+      <p className="mt-6 max-w-3xl text-base leading-relaxed text-[rgba(255,255,255,0.7)] md:text-lg">
+        {educationCopy.description}
+      </p>
+      {educationCopy.highlights.length ? (
+        <ul className="mt-8 flex flex-wrap gap-2 text-sm text-[rgba(255,255,255,0.7)]">
+          {educationCopy.highlights.map((highlight) => (
+            <li
+              key={highlight}
+              className="rounded-full border border-[rgba(34,211,238,0.3)] bg-[rgba(34,211,238,0.1)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#f1f5f9]"
+            >
+              {highlight}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="mt-8 flex flex-wrap items-center gap-3">
+        <a
+          href={educationCopy.transcriptLink}
+          className={`inline-flex items-center gap-2 ${primaryButtonClasses}`}
+          download
+        >
+          {educationCopy.transcriptCta}
+        </a>
+        {educationCopy.transcriptNote ? (
+          <p className="text-xs uppercase tracking-[0.3em] text-[rgba(255,255,255,0.4)]">
+            {educationCopy.transcriptNote}
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- move the contact information section above the “Sobre mí” block and restyle it to match the shared gradient layout
- introduce a new education section with matching typography and a transcript download button
- extend translations/navigation for the new structure and ship a placeholder analytic transcript asset

## Testing
- npm run build *(fails: Cannot find module 'pdf-lib' or its corresponding type declarations.)*

------
https://chatgpt.com/codex/tasks/task_e_68e198acf1948332b4309294c3264ca1