### PR TITLE
Update contact and education sections with personal details

### DIFF
--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -48,6 +48,8 @@ interface ContactDetailTranslation {
   label: string;
   value: string;
   href?: string;
+  dateISO?: string;
+  ageSuffix?: string;
 }
 
 interface ContactTranslation {
@@ -146,40 +148,51 @@ export const translations: Record<Language, Translation> = {
     contact: {
       heading: "Información de contacto",
       description:
-        "¿Tenés un proyecto, integración o idea en mente? Hablemos y diseñemos una solución a medida.",
+        "Hablemos sobre proyectos, integraciones o automatizaciones para tu negocio. Estoy disponible para colaborar en soluciones a medida.",
       button: "Escribime por mail",
-      note: "Actualizá los datos de contacto según tus canales preferidos.",
-      email: "tu-email@ejemplo.com",
-      mailSubject: "Consulta desde tu CV web",
+      note: "Actualizá estos datos si necesitás sumar nuevos canales de contacto.",
+      email: "gaspar.rambo@gmail.com",
+      mailSubject: "Consulta desde gasparrambo.dev",
       mailBody: "Hola Gaspar, me gustaría contactarte por...",
       details: [
         {
+          label: "Dirección",
+          value: "Villa Dolores, Córdoba · CP 5870 · Argentina"
+        },
+        {
+          label: "Teléfono",
+          value: "+54 280 434 2550",
+          href: "tel:+542804342550"
+        },
+        {
           label: "Email",
-          value: "tu-email@ejemplo.com",
-          href: "mailto:tu-email@ejemplo.com"
+          value: "gaspar.rambo@gmail.com",
+          href: "mailto:gaspar.rambo@gmail.com"
+        },
+        {
+          label: "Fecha de nacimiento",
+          value: "17 de enero de 1992",
+          dateISO: "1992-01-17",
+          ageSuffix: "años"
         },
         {
           label: "LinkedIn",
-          value: "linkedin.com/in/tu-usuario",
-          href: "https://www.linkedin.com/in/tu-usuario"
-        },
-        {
-          label: "Ubicación",
-          value: "Argentina"
+          value: "linkedin.com/in/gaspar-rambo-a24ab3a0",
+          href: "https://www.linkedin.com/in/gaspar-rambo-a24ab3a0/"
         }
       ]
     },
     education: {
       heading: "Formación académica",
       description:
-        "Trayectoria educativa enfocada en el desarrollo de software, automatización y soluciones impulsadas por IA para e-commerce.",
+        "Tecnicatura superior orientada al desarrollo de software, bases de datos y automatización de procesos para soluciones digitales.",
       highlights: [
-        "Programas intensivos de desarrollo web orientados a integraciones y automatización",
-        "Capacitación continua en herramientas IA aplicadas a experiencias digitales"
+        "Tecnicatura Superior en Programación · Instituto Técnico Superior TECLAB",
+        "Condición: Egresado · 2023"
       ],
       transcriptCta: "Descargar analítico",
-      transcriptLink: "/analitico.pdf",
-      transcriptNote: "Actualizá el archivo con tu analítico oficial."
+      transcriptLink: "/docs/analitico-gaspar-rambo.pdf",
+      transcriptNote: "Guardá el archivo en public/docs/analitico-gaspar-rambo.pdf"
     },
     footer: {
       signature: "Hecho con React + Tailwind",
@@ -237,40 +250,51 @@ export const translations: Record<Language, Translation> = {
     contact: {
       heading: "Contact information",
       description:
-        "Working on an integration, automation, or custom build? Let’s design the right solution together.",
+        "Let’s collaborate on integrations, automations, or tailored software that supports your business goals.",
       button: "Email me",
-      note: "Update these details with your preferred contact channels.",
-      email: "your-email@example.com",
-      mailSubject: "Enquiry from your online résumé",
+      note: "Update these details whenever you add new contact channels.",
+      email: "gaspar.rambo@gmail.com",
+      mailSubject: "Enquiry from gasparrambo.dev",
       mailBody: "Hi Gaspar, I’d like to connect regarding...",
       details: [
         {
+          label: "Address",
+          value: "Villa Dolores, Córdoba · ZIP 5870 · Argentina"
+        },
+        {
+          label: "Phone",
+          value: "+54 280 434 2550",
+          href: "tel:+542804342550"
+        },
+        {
           label: "Email",
-          value: "your-email@example.com",
-          href: "mailto:your-email@example.com"
+          value: "gaspar.rambo@gmail.com",
+          href: "mailto:gaspar.rambo@gmail.com"
+        },
+        {
+          label: "Birth date",
+          value: "17 January 1992",
+          dateISO: "1992-01-17",
+          ageSuffix: "years old"
         },
         {
           label: "LinkedIn",
-          value: "linkedin.com/in/your-handle",
-          href: "https://www.linkedin.com/in/your-handle"
-        },
-        {
-          label: "Location",
-          value: "Argentina"
+          value: "linkedin.com/in/gaspar-rambo-a24ab3a0",
+          href: "https://www.linkedin.com/in/gaspar-rambo-a24ab3a0/"
         }
       ]
     },
     education: {
       heading: "Education",
       description:
-        "Learning path focused on software development, automation, and AI-assisted experiences for commerce.",
+        "Higher technical degree focused on software development, databases, and process automation for digital solutions.",
       highlights: [
-        "Intensive web development programmes specialising in integrations and automation",
-        "Continuous upskilling with AI tooling tailored to digital product delivery"
+        "Higher Technician in Programming · Instituto Técnico Superior TECLAB",
+        "Status: Graduate · 2023"
       ],
       transcriptCta: "Download transcript",
-      transcriptLink: "/analitico.pdf",
-      transcriptNote: "Replace the file with your official academic record."
+      transcriptLink: "/docs/analitico-gaspar-rambo.pdf",
+      transcriptNote: "Place the file at public/docs/analitico-gaspar-rambo.pdf"
     },
     footer: {
       signature: "Built with React + Tailwind",

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -3,6 +3,26 @@ import { useLanguage } from "../hooks/useLanguage";
 const primaryButtonClasses =
   "rounded-full bg-[#ec4899] px-6 py-2.5 text-sm font-semibold text-[#0f172a] shadow-[0_20px_60px_rgba(236,72,153,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[rgba(236,72,153,0.9)]";
 
+const calculateAgeFromIsoDate = (dateISO: string): number | null => {
+  const [year, month, day] = dateISO.split("-").map(Number);
+
+  if ([year, month, day].some((value) => Number.isNaN(value))) {
+    return null;
+  }
+
+  const today = new Date();
+  let age = today.getFullYear() - year;
+  const hasHadBirthdayThisYear =
+    today.getMonth() + 1 > month ||
+    (today.getMonth() + 1 === month && today.getDate() >= day);
+
+  if (!hasHadBirthdayThisYear) {
+    age -= 1;
+  }
+
+  return age;
+};
+
 export default function Contact() {
   const { content } = useLanguage();
   const contactCopy = content.contact;
@@ -20,6 +40,26 @@ export default function Contact() {
         },
       ];
 
+  const formattedDetails = details.map((detail) => {
+    if (!detail.dateISO) {
+      return { ...detail, displayValue: detail.value };
+    }
+
+    const age = calculateAgeFromIsoDate(detail.dateISO);
+
+    if (age === null) {
+      return { ...detail, displayValue: detail.value };
+    }
+
+    const suffix = detail.ageSuffix ? ` ${detail.ageSuffix}` : "";
+    const ageText = `${age}${suffix}`;
+
+    return {
+      ...detail,
+      displayValue: `${detail.value} (${ageText})`,
+    };
+  });
+
   return (
     <section id="contacto" className="scroll-mt-24 py-20">
       <div>
@@ -34,18 +74,18 @@ export default function Contact() {
         {contactCopy.description}
       </p>
       <ul className="mt-8 flex flex-wrap gap-2 text-sm text-[rgba(255,255,255,0.7)]">
-        {details.map((detail) => (
+        {formattedDetails.map((detail) => (
           <li
             key={`${detail.label}-${detail.value}`}
             className="rounded-full border border-[rgba(34,211,238,0.3)] bg-[rgba(34,211,238,0.1)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#f1f5f9]"
           >
             {detail.href ? (
               <a href={detail.href} className="transition-colors hover:text-[rgba(255,255,255,0.8)]">
-                <span className="font-semibold text-[#22d3ee]">{detail.label}:</span> {detail.value}
+                <span className="font-semibold text-[#22d3ee]">{detail.label}:</span> {detail.displayValue}
               </a>
             ) : (
               <span>
-                <span className="font-semibold text-[#22d3ee]">{detail.label}:</span> {detail.value}
+                <span className="font-semibold text-[#22d3ee]">{detail.label}:</span> {detail.displayValue}
               </span>
             )}
           </li>


### PR DESCRIPTION
## Summary
- replace placeholder contact copy with Gaspar Rambo's address, phone, email, birth date, and LinkedIn
- calculate current age dynamically from the stored birth date when rendering contact details
- refresh education section content and transcript download path to highlight the TECLAB degree and graduation status

## Testing
- npm run build *(fails: missing optional dependency pdf-lib)*

------
https://chatgpt.com/codex/tasks/task_e_68e19b9b01e88332bb577d5f07bde2a7