### PR TITLE
Add certifications section and update education messaging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Navbar from "./components/Navbar";
 import Hero from "./sections/Hero";
 import About from "./sections/About";
 import Education from "./sections/Education";
+import Certifications from "./sections/Certifications";
 import Projects from "./sections/Projects";
 import Experience from "./sections/Experience";
 import Contact from "./sections/Contact";
@@ -467,6 +468,7 @@ function AppContent({ pageRef, onDownloadCv }: AppContentProps) {
           <Contact />
           <About />
           <Education />
+          <Certifications />
           <Projects items={projectsByLanguage[language]} />
           <Experience items={jobsByLanguage[language]} />
         </main>

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -56,7 +56,7 @@ interface ContactTranslation {
   heading: string;
   description: string;
   button: string;
-  note: string;
+  note?: string;
   email: string;
   mailSubject: string;
   mailBody: string;
@@ -69,7 +69,26 @@ interface EducationTranslation {
   highlights: string[];
   transcriptCta: string;
   transcriptLink: string;
-  transcriptNote?: string;
+}
+
+interface CertificationResourceTranslation {
+  label: string;
+  href: string;
+  download?: string;
+}
+
+interface CertificationItemTranslation {
+  title: string;
+  issuer: string;
+  issueDate: string;
+  credentialId?: string;
+  tags?: string[];
+  resource: CertificationResourceTranslation;
+}
+
+interface CertificationsTranslation {
+  heading: string;
+  items: CertificationItemTranslation[];
 }
 
 interface FooterTranslation {
@@ -86,12 +105,14 @@ export interface Translation {
   experience: ExperienceTranslation;
   contact: ContactTranslation;
   education: EducationTranslation;
+  certifications: CertificationsTranslation;
   footer: FooterTranslation;
 }
 
 const sectionAnchors = {
   about: "#sobre-mi",
   education: "#formacion-academica",
+  certifications: "#licencias-certificaciones",
   projects: "#proyectos",
   experience: "#experiencia",
   contact: "#contacto"
@@ -104,6 +125,7 @@ export const translations: Record<Language, Translation> = {
         { href: sectionAnchors.contact, label: "Contacto" },
         { href: sectionAnchors.about, label: "Sobre mí" },
         { href: sectionAnchors.education, label: "Formación académica" },
+        { href: sectionAnchors.certifications, label: "Licencias y certificaciones" },
         { href: sectionAnchors.projects, label: "Proyectos" },
         { href: sectionAnchors.experience, label: "Experiencia" }
       ],
@@ -150,7 +172,6 @@ export const translations: Record<Language, Translation> = {
       description:
         "Hablemos sobre proyectos, integraciones o automatizaciones para tu negocio. Estoy disponible para colaborar en soluciones a medida.",
       button: "Escribime por mail",
-      note: "Actualizá estos datos si necesitás sumar nuevos canales de contacto.",
       email: "gaspar.rambo@gmail.com",
       mailSubject: "Consulta desde gasparrambo.dev",
       mailBody: "Hola Gaspar, me gustaría contactarte por...",
@@ -192,7 +213,34 @@ export const translations: Record<Language, Translation> = {
       ],
       transcriptCta: "Descargar analítico",
       transcriptLink: "/docs/analitico-gaspar-rambo.pdf",
-      transcriptNote: "Guardá el archivo en public/docs/analitico-gaspar-rambo.pdf"
+    },
+    certifications: {
+      heading: "Licencias y certificaciones",
+      items: [
+        {
+          title: "Google: Inteligencia Artificial y productividad",
+          issuer: "Google",
+          issueDate: "Expedición: jul. 2024",
+          credentialId: "ID de la credencial: OA-2024-0710000017680",
+          tags: ["IA y Google Gemini"],
+          resource: {
+            label: "Ver credencial",
+            href: "/docs/certificate-google-ia.pdf",
+            download: "certificate-google-ia.pdf",
+          },
+        },
+        {
+          title: "EFSET English Certificate 75/100 (C2 Proficient)",
+          issuer: "EF SET",
+          issueDate: "Expedición: jul. 2024",
+          tags: ["Habla", "Comprensión lectora"],
+          resource: {
+            label: "Mostrar credencial",
+            href: "/docs/certificate-efset-english-75-100.pdf",
+            download: "certificate-efset-english-75-100.pdf",
+          },
+        },
+      ],
     },
     footer: {
       signature: "Hecho con React + Tailwind",
@@ -206,6 +254,7 @@ export const translations: Record<Language, Translation> = {
         { href: sectionAnchors.contact, label: "Contact info" },
         { href: sectionAnchors.about, label: "About" },
         { href: sectionAnchors.education, label: "Education" },
+        { href: sectionAnchors.certifications, label: "Licenses & certifications" },
         { href: sectionAnchors.projects, label: "Projects" },
         { href: sectionAnchors.experience, label: "Experience" }
       ],
@@ -252,7 +301,6 @@ export const translations: Record<Language, Translation> = {
       description:
         "Let’s collaborate on integrations, automations, or tailored software that supports your business goals.",
       button: "Email me",
-      note: "Update these details whenever you add new contact channels.",
       email: "gaspar.rambo@gmail.com",
       mailSubject: "Enquiry from gasparrambo.dev",
       mailBody: "Hi Gaspar, I’d like to connect regarding...",
@@ -293,8 +341,35 @@ export const translations: Record<Language, Translation> = {
         "Status: Graduate · 2023"
       ],
       transcriptCta: "Download transcript",
-      transcriptLink: "/docs/analitico-gaspar-rambo.pdf",
-      transcriptNote: "Place the file at public/docs/analitico-gaspar-rambo.pdf"
+      transcriptLink: "/docs/analitico-gaspar-rambo.pdf"
+    },
+    certifications: {
+      heading: "Licenses & certifications",
+      items: [
+        {
+          title: "Google: Artificial Intelligence and Productivity",
+          issuer: "Google",
+          issueDate: "Issued: Jul 2024",
+          credentialId: "Credential ID: OA-2024-0710000017680",
+          tags: ["AI & Google Gemini"],
+          resource: {
+            label: "View credential",
+            href: "/docs/certificate-google-ia.pdf",
+            download: "certificate-google-ia.pdf",
+          },
+        },
+        {
+          title: "EFSET English Certificate 75/100 (C2 Proficient)",
+          issuer: "EF SET",
+          issueDate: "Issued: Jul 2024",
+          tags: ["Speaking", "Reading comprehension"],
+          resource: {
+            label: "Show credential",
+            href: "/docs/certificate-efset-english-75-100.pdf",
+            download: "certificate-efset-english-75-100.pdf",
+          },
+        },
+      ],
     },
     footer: {
       signature: "Built with React + Tailwind",

--- a/src/sections/Certifications.tsx
+++ b/src/sections/Certifications.tsx
@@ -1,0 +1,68 @@
+import { useLanguage } from "../hooks/useLanguage";
+
+const cardClasses =
+  "flex h-full flex-col justify-between rounded-3xl border border-[rgba(148,163,184,0.2)] bg-[rgba(15,23,42,0.6)] p-6 backdrop-blur";
+
+const primaryButtonClasses =
+  "inline-flex items-center justify-center rounded-full bg-[#22d3ee] px-5 py-2 text-sm font-semibold text-[#0f172a] shadow-[0_12px_30px_rgba(34,211,238,0.35)] transition-transform hover:-translate-y-0.5 hover:bg-[rgba(34,211,238,0.9)]";
+
+export default function Certifications() {
+  const { content } = useLanguage();
+  const { certifications } = content;
+
+  if (!certifications.items.length) {
+    return null;
+  }
+
+  return (
+    <section id="licencias-certificaciones" className="scroll-mt-24 py-20">
+      <div>
+        <h2 className="text-3xl font-bold md:text-4xl">
+          <span className="bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-[#22d3ee] bg-clip-text text-transparent">
+            {certifications.heading}
+          </span>
+        </h2>
+        <div className="mt-3 h-[3px] w-24 rounded-full bg-gradient-to-r from-[#ec4899] via-[#6366f1] to-transparent" />
+      </div>
+      <div className="mt-10 grid gap-6 md:grid-cols-2">
+        {certifications.items.map((item) => (
+          <article key={item.title} className={cardClasses}>
+            <div>
+              <h3 className="text-xl font-semibold text-[#f8fafc]">{item.title}</h3>
+              <p className="mt-2 text-sm text-[rgba(255,255,255,0.7)]">
+                <span className="font-semibold text-[#22d3ee]">{item.issuer}</span>
+              </p>
+              <p className="mt-2 text-xs uppercase tracking-[0.3em] text-[rgba(255,255,255,0.4)]">
+                {item.issueDate}
+              </p>
+              {item.credentialId ? (
+                <p className="mt-2 text-xs text-[rgba(255,255,255,0.6)]">{item.credentialId}</p>
+              ) : null}
+              {item.tags && item.tags.length ? (
+                <ul className="mt-4 flex flex-wrap gap-2 text-[0.7rem] uppercase tracking-wide text-[rgba(255,255,255,0.7)]">
+                  {item.tags.map((tag) => (
+                    <li
+                      key={tag}
+                      className="rounded-full border border-[rgba(99,102,241,0.3)] bg-[rgba(99,102,241,0.1)] px-3 py-1"
+                    >
+                      {tag}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+            <div className="mt-6">
+              <a
+                href={item.resource.href}
+                className={primaryButtonClasses}
+                download={item.resource.download}
+              >
+                {item.resource.label}
+              </a>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -94,7 +94,11 @@ export default function Contact() {
       <a href={mailto} className={`mt-8 inline-flex items-center gap-2 ${primaryButtonClasses}`}>
         {contactCopy.button}
       </a>
-      <p className="mt-4 text-xs uppercase tracking-[0.3em] text-[rgba(255,255,255,0.4)]">{contactCopy.note}</p>
+      {contactCopy.note ? (
+        <p className="mt-4 text-xs uppercase tracking-[0.3em] text-[rgba(255,255,255,0.4)]">
+          {contactCopy.note}
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/src/sections/Education.tsx
+++ b/src/sections/Education.tsx
@@ -40,11 +40,6 @@ export default function Education() {
         >
           {educationCopy.transcriptCta}
         </a>
-        {educationCopy.transcriptNote ? (
-          <p className="text-xs uppercase tracking-[0.3em] text-[rgba(255,255,255,0.4)]">
-            {educationCopy.transcriptNote}
-          </p>
-        ) : null}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- remove placeholder helper notes from the contact and education content
- add a dedicated licenses and certifications section with downloadable credentials
- update navigation and layout to surface the new section in both languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2de237ba88332b92a641344d12181