### PR TITLE
Update site title and favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/gr-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Gaspar Rambo | Portfolio</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/gr-logo.svg
+++ b/public/gr-logo.svg
@@ -1,0 +1,30 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grGradient" x1="16" y1="16" x2="112" y2="112" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#22d3ee" />
+      <stop offset="0.55" stop-color="#6366f1" />
+      <stop offset="1" stop-color="#ec4899" />
+    </linearGradient>
+    <filter id="grGlow" x="0" y="0" width="128" height="128" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="14" result="blur" />
+    </filter>
+  </defs>
+  <rect x="12" y="12" width="104" height="104" rx="28" fill="url(#grGradient)" />
+  <g opacity="0.22" filter="url(#grGlow)">
+    <path d="M64 6C32.833 6 7 31.833 7 63C7 94.167 32.833 120 64 120C95.167 120 121 94.167 121 63C121 31.833 95.167 6 64 6Z" fill="url(#grGradient)" />
+  </g>
+  <rect x="20" y="20" width="88" height="88" rx="24" fill="#0f172a" fill-opacity="0.9" />
+  <text
+    x="50%"
+    y="50%"
+    dominant-baseline="middle"
+    text-anchor="middle"
+    font-family="'Inter', 'Segoe UI', sans-serif"
+    font-weight="600"
+    font-size="42"
+    letter-spacing="8"
+    fill="#e0f2fe"
+  >
+    GR
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- update the document title to "Gaspar Rambo | Portfolio" so the browser tab matches the personal branding
- replace the default Vite favicon with a custom GR icon that mirrors the navigation logo styling

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: missing optional dependencies @vercel/analytics/react and @vercel/speed-insights/react)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e6eb6e788332b6f12ea33281a35c