### PR TITLE
Add particle background and WhatsApp button to budget page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,15 +107,6 @@ export default function App() {
   const budgetSlug =
     typeof window !== "undefined" ? getBudgetSlugFromPath(window.location.pathname) : null;
   const budgetData = budgetSlug ? budgets[budgetSlug] : null;
-
-  if (budgetSlug) {
-    if (budgetData) {
-      return <BudgetPage data={budgetData} />;
-    }
-
-    return <BudgetNotFound slug={budgetSlug} />;
-  }
-
   const pageRef = useRef<HTMLDivElement | null>(null);
 
   const handleDownloadCv = useCallback((language: Language) => {
@@ -139,9 +130,15 @@ export default function App() {
     document.body.removeChild(link);
   }, []);
 
+  const content = budgetSlug
+    ? budgetData
+      ? <BudgetPage data={budgetData} />
+      : <BudgetNotFound slug={budgetSlug} />
+    : <AppContent pageRef={pageRef} onDownloadCv={handleDownloadCv} />;
+
   return (
     <LanguageProvider>
-      <AppContent pageRef={pageRef} onDownloadCv={handleDownloadCv} />
+      {content}
       <Analytics />
       <SpeedInsights />
     </LanguageProvider>

--- a/src/pages/BudgetPage.tsx
+++ b/src/pages/BudgetPage.tsx
@@ -1,3 +1,5 @@
+import FloatingWhatsappButton from "../components/FloatingWhatsappButton";
+import ParticleBackground from "../components/ParticleBackground";
 import type { Budget } from "../types/budget";
 
 type BudgetPageProps = {
@@ -13,57 +15,61 @@ const InfoItem = ({ label, value }: { label: string; value: string }) => (
 
 export default function BudgetPage({ data }: BudgetPageProps) {
   return (
-    <div className="min-h-screen bg-[#0f172a] px-4 py-10 text-[#f8fafc]">
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-10 rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur">
-        <header className="flex flex-col gap-2 text-center">
-          <p className="text-sm uppercase tracking-[0.3em] text-[#38bdf8]">Presupuesto digital</p>
-          <h1 className="text-3xl font-bold text-white sm:text-4xl">{data.title}</h1>
-          <p className="text-white/70">
-            Documento reutilizable alojado en el dominio principal para compartir propuestas de manera profesional.
-          </p>
-        </header>
+    <div className="relative min-h-screen overflow-hidden bg-[#0f172a] px-4 py-10 text-[#f8fafc]">
+      <ParticleBackground />
+      <FloatingWhatsappButton />
+      <div className="relative z-10">
+        <div className="mx-auto flex w-full max-w-4xl flex-col gap-10 rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur">
+          <header className="flex flex-col gap-2 text-center">
+            <p className="text-sm uppercase tracking-[0.3em] text-[#38bdf8]">Presupuesto digital</p>
+            <h1 className="text-3xl font-bold text-white sm:text-4xl">{data.title}</h1>
+            <p className="text-white/70">
+              Documento reutilizable alojado en el dominio principal para compartir propuestas de manera profesional.
+            </p>
+          </header>
 
-        <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <InfoItem label="Cliente" value={data.client} />
-          <InfoItem label="Desarrollador" value={data.developer} />
-          <InfoItem label="Fecha" value={data.date} />
-          <InfoItem label="Validez" value={data.validity} />
-        </section>
+          <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <InfoItem label="Cliente" value={data.client} />
+            <InfoItem label="Desarrollador" value={data.developer} />
+            <InfoItem label="Fecha" value={data.date} />
+            <InfoItem label="Validez" value={data.validity} />
+          </section>
 
-        <section className="rounded-2xl border border-white/10 bg-[#0b1221]/70 p-6">
-          <h2 className="mb-4 text-lg font-semibold text-white">Resumen del Proyecto</h2>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <InfoItem label="Tipo de proyecto" value={data.summary.projectType} />
-            <InfoItem label="Valor total" value={data.summary.totalValue} />
-            <InfoItem label="Plazo estimado" value={data.summary.estimatedTimeline} />
-            <InfoItem label="Pago" value={data.summary.paymentSchedule} />
-          </div>
-        </section>
+          <section className="rounded-2xl border border-white/10 bg-[#0b1221]/70 p-6">
+            <h2 className="mb-4 text-lg font-semibold text-white">Resumen del Proyecto</h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <InfoItem label="Tipo de proyecto" value={data.summary.projectType} />
+              <InfoItem label="Valor total" value={data.summary.totalValue} />
+              <InfoItem label="Plazo estimado" value={data.summary.estimatedTimeline} />
+              <InfoItem label="Pago" value={data.summary.paymentSchedule} />
+            </div>
+          </section>
 
-        <section className="flex flex-col gap-6">
-          {data.sections.map((section) => (
-            <article key={section.title} className="rounded-2xl border border-white/10 bg-[#0b1221]/70 p-6">
-              <h3 className="text-lg font-semibold text-white">{section.title}</h3>
-              {section.description && (
-                <p className="mt-3 text-white/80 leading-relaxed">{section.description}</p>
-              )}
-              {section.items && (
-                <ul className="mt-4 list-disc space-y-2 pl-5 text-white/80">
-                  {section.items.map((item) => (
-                    <li key={item}>{item}</li>
-                  ))}
-                </ul>
-              )}
-            </article>
-          ))}
-        </section>
+          <section className="flex flex-col gap-6">
+            {data.sections.map((section) => (
+              <article key={section.title} className="rounded-2xl border border-white/10 bg-[#0b1221]/70 p-6">
+                <h3 className="text-lg font-semibold text-white">{section.title}</h3>
+                {section.description && (
+                  <p className="mt-3 text-white/80 leading-relaxed">{section.description}</p>
+                )}
+                {section.items && (
+                  <ul className="mt-4 list-disc space-y-2 pl-5 text-white/80">
+                    {section.items.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                )}
+              </article>
+            ))}
+          </section>
 
-        <footer className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-white/80">
-          <p>
-            ¿Necesitas otra versión de este presupuesto? Actualiza el contenido en <code>src/data/budgets.ts</code> y comparte
-            la URL única desde <span className="font-semibold">presupuestos.tudominio.com</span> u otro subdominio.
-          </p>
-        </footer>
+          <footer className="rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-white/80">
+            <p>
+              ¿Necesitas otra versión de este presupuesto? Actualiza el contenido en <code>src/data/budgets.ts</code> y comparte
+              la URL única desde <span className="font-semibold">presupuestos.tudominio.com</span> u otro subdominio.
+            </p>
+          </footer>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- always wrap rendered pages in the language provider so shared UI such as the WhatsApp button has access to localized copy
- add the particle background and floating WhatsApp button to the budget page so it matches the main CV experience

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691902dc09ec8332b4804c33bcd0b15e)